### PR TITLE
Add mobile navbar toggle

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -15,7 +15,10 @@
 <nav class="navbar navbar-expand-lg navbar-light bg-light mb-4">
   <div class="container-fluid">
     <a class="navbar-brand" href="{{ url_for('main.dashboard') }}">DebateHub</a>
-    <div class="collapse navbar-collapse">
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarNav">
       <ul class="navbar-nav ms-auto">
         <li class="nav-item">
           <a class="nav-link" href="{{ url_for('profile.view') }}">Profile</a>


### PR DESCRIPTION
## Summary
- add Bootstrap navbar toggler so the menu is accessible on mobile devices

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b49d6cb248330a6c7670ae890d9eb