### PR TITLE
Implement simple debate judging system

### DIFF
--- a/app/debate/__init__.py
+++ b/app/debate/__init__.py
@@ -1,2 +1,5 @@
 from flask import Blueprint
+
 debate_bp = Blueprint('debate', __name__)
+
+from . import routes  # noqa: E402

--- a/app/debate/routes.py
+++ b/app/debate/routes.py
@@ -1,0 +1,57 @@
+from flask import render_template, request, redirect, url_for, flash
+from flask_login import login_required, current_user
+from app.extensions import db
+from app.models import Debate, SpeakerSlot, Score, BpRank
+
+from . import debate_bp
+
+
+def is_chair(user, debate_id):
+    slot = SpeakerSlot.query.filter_by(debate_id=debate_id, user_id=user.id, role='Judge-Chair').first()
+    return slot is not None
+
+
+@debate_bp.route('/debate/<int:debate_id>/judging', methods=['GET', 'POST'])
+@login_required
+def judging(debate_id):
+    debate = Debate.query.get_or_404(debate_id)
+    if not is_chair(current_user, debate_id):
+        flash('Only the chair judge can access this page.', 'danger')
+        return redirect(url_for('main.debate_view', debate_id=debate_id))
+
+    judges = SpeakerSlot.query.filter(
+        SpeakerSlot.debate_id == debate_id,
+        SpeakerSlot.role.startswith('Judge')
+    ).all()
+
+    if debate.style == 'BP':
+        if request.method == 'POST':
+            BpRank.query.filter_by(debate_id=debate_id).delete()
+            for team in ['OG', 'OO', 'CG', 'CO']:
+                val = request.form.get(f'rank_{team}')
+                if val:
+                    db.session.add(BpRank(debate_id=debate_id, team=team, rank=int(val)))
+            db.session.commit()
+            flash('Rankings saved.', 'success')
+            return redirect(url_for('debate.judging', debate_id=debate_id))
+        existing = {r.team: r.rank for r in BpRank.query.filter_by(debate_id=debate_id).all()}
+        return render_template('debate/judging_bp.html', debate=debate, existing=existing)
+
+    speakers = SpeakerSlot.query.filter(
+        SpeakerSlot.debate_id == debate_id,
+        ~SpeakerSlot.role.startswith('Judge')
+    ).all()
+    if request.method == 'POST':
+        Score.query.filter_by(debate_id=debate_id).delete()
+        for sp in speakers:
+            for j in judges:
+                key = f'score_{sp.id}_{j.id}'
+                val = request.form.get(key)
+                if val:
+                    db.session.add(Score(debate_id=debate_id, speaker_id=sp.user_id,
+                                         judge_id=j.user_id, value=int(val)))
+        db.session.commit()
+        flash('Scores saved.', 'success')
+        return redirect(url_for('debate.judging', debate_id=debate_id))
+    scores = {(s.speaker_id, s.judge_id): s.value for s in Score.query.filter_by(debate_id=debate_id).all()}
+    return render_template('debate/judging_opd.html', debate=debate, judges=judges, speakers=speakers, scores=scores)

--- a/app/models.py
+++ b/app/models.py
@@ -132,3 +132,24 @@ class SpeakerSlot(db.Model):
     room = db.Column(db.Integer, default=1)            # For split debates (1 or 2)
     # Ensure each user is only assigned once per debate per room
     __table_args__ = (db.UniqueConstraint('debate_id', 'user_id', 'room', name='_debate_user_room_uc'),)
+
+
+class Score(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    debate_id = db.Column(db.Integer, db.ForeignKey('debate.id'), nullable=False)
+    speaker_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    judge_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    value = db.Column(db.Integer, nullable=False)
+    __table_args__ = (
+        db.UniqueConstraint('debate_id', 'speaker_id', 'judge_id', name='score_unique'),
+    )
+
+
+class BpRank(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    debate_id = db.Column(db.Integer, db.ForeignKey('debate.id'), nullable=False)
+    team = db.Column(db.String(8), nullable=False)
+    rank = db.Column(db.Integer, nullable=False)
+    __table_args__ = (
+        db.UniqueConstraint('debate_id', 'team', name='bp_rank_unique'),
+    )

--- a/app/templates/debate/judging_bp.html
+++ b/app/templates/debate/judging_bp.html
@@ -1,0 +1,32 @@
+{% extends "base.html" %}
+{% block title %}BP Ranking - {{ debate.title }}{% endblock %}
+{% block content %}
+<h2 class="mb-4">{{ debate.title }} – Rankings</h2>
+<form method="post">
+  <table class="table table-bordered w-auto">
+    <thead><tr><th>Team</th><th>Rank (1-4)</th></tr></thead>
+    <tbody>
+      {% for t in ['OG','OO','CG','CO'] %}
+      <tr>
+        <td>{{ t }}</td>
+        <td><input type="number" name="rank_{{ t }}" class="form-control rank-input" min="1" max="4" value="{{ existing.get(t, '') }}"></td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  <p id="rank-warning" class="text-danger d-none">Each rank must be used once.</p>
+  <button type="submit" class="btn btn-primary">Save</button>
+</form>
+{% endblock %}
+{% block extra_js %}
+<script>
+function check() {
+  const vals = Array.from(document.querySelectorAll('.rank-input')).map(i=>i.value);
+  const used = vals.filter(v=>v);
+  const ok = new Set(used).size===4 && used.length===4;
+  document.getElementById('rank-warning').classList.toggle('d-none', ok);
+}
+document.querySelectorAll('.rank-input').forEach(i=>i.addEventListener('input', check));
+check();
+</script>
+{% endblock %}

--- a/app/templates/debate/judging_opd.html
+++ b/app/templates/debate/judging_opd.html
@@ -1,0 +1,53 @@
+{% extends "base.html" %}
+{% block title %}Judging - {{ debate.title }}{% endblock %}
+{% block content %}
+<h2 class="mb-4">{{ debate.title }} – Scoring</h2>
+<form method="post">
+  <table class="table table-bordered">
+    <thead>
+      <tr>
+        <th>Speaker</th>
+        {% for j in judges %}
+          <th>{{ j.user.username }}</th>
+        {% endfor %}
+        <th>Average</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for sp in speakers %}
+      <tr data-role="{{ sp.role }}" data-sid="{{ sp.id }}">
+        <td>{{ sp.user.username }} <small class="text-muted">({{ sp.role }})</small></td>
+        {% for j in judges %}
+          <td><input type="number" min="0" max="100" step="1" name="score_{{ sp.id }}_{{ j.id }}" class="form-control score-input" value="{{ scores.get((sp.user_id, j.user_id), '') }}"></td>
+        {% endfor %}
+        <td class="avg">0</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  <p><strong>Government:</strong> <span id="gov-total">0</span></p>
+  <p><strong>Opposition:</strong> <span id="opp-total">0</span></p>
+  <button type="submit" class="btn btn-primary">Save</button>
+</form>
+{% endblock %}
+{% block extra_js %}
+<script>
+function update() {
+  let gov=0, opp=0;
+  document.querySelectorAll('tbody tr').forEach(row=>{
+    let sum=0,count=0;
+    row.querySelectorAll('.score-input').forEach(inp=>{
+      const v=parseFloat(inp.value); if(!isNaN(v)){sum+=v;count++;}
+    });
+    const avg = count?sum/count:0;
+    row.querySelector('.avg').textContent=avg.toFixed(1);
+    if(row.dataset.role.startsWith('Gov')) gov+=avg;
+    else if(row.dataset.role.startsWith('Opp')) opp+=avg;
+  });
+  document.getElementById('gov-total').textContent=gov.toFixed(1);
+  document.getElementById('opp-total').textContent=opp.toFixed(1);
+}
+update();
+document.querySelectorAll('.score-input').forEach(inp=>inp.addEventListener('input', update));
+</script>
+{% endblock %}

--- a/app/templates/main/debate.html
+++ b/app/templates/main/debate.html
@@ -41,5 +41,9 @@
     <a href="{{ url_for('main.debate_graphic', debate_id=debate.id) }}" class="btn btn-primary mt-3">
         View Speaker Positions
     </a>
+    {% set my_slot = current_user.get_slot_for_debate(debate.id) %}
+    {% if my_slot and my_slot.role == 'Judge-Chair' %}
+      <a href="{{ url_for('debate.judging', debate_id=debate.id) }}" class="btn btn-warning mt-3">Judging</a>
+    {% endif %}
 {% endif %}
 {% endblock %}

--- a/migrations/versions/0d2e6c501f2d_add_judging.py
+++ b/migrations/versions/0d2e6c501f2d_add_judging.py
@@ -1,0 +1,36 @@
+"""add judging models"""
+
+revision = '0d2e6c501f2d'
+down_revision = 'ee128683fcd2'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+def upgrade():
+    op.create_table(
+        'score',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('debate_id', sa.Integer(), nullable=False),
+        sa.Column('speaker_id', sa.Integer(), nullable=False),
+        sa.Column('judge_id', sa.Integer(), nullable=False),
+        sa.Column('value', sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(['debate_id'], ['debate.id']),
+        sa.ForeignKeyConstraint(['speaker_id'], ['user.id']),
+        sa.ForeignKeyConstraint(['judge_id'], ['user.id']),
+        sa.UniqueConstraint('debate_id', 'speaker_id', 'judge_id', name='score_unique')
+    )
+    op.create_table(
+        'bp_rank',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('debate_id', sa.Integer(), nullable=False),
+        sa.Column('team', sa.String(length=8), nullable=False),
+        sa.Column('rank', sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(['debate_id'], ['debate.id']),
+        sa.UniqueConstraint('debate_id', 'team', name='bp_rank_unique')
+    )
+
+def downgrade():
+    op.drop_table('bp_rank')
+    op.drop_table('score')


### PR DESCRIPTION
## Summary
- create tables `Score` and `BpRank`
- add judging routes and templates
- allow Chair judges to open judging page from debate view
- include migration for new tables

## Testing
- `flask db upgrade`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b4da2c5048330809f9328334c2b62