### PR TITLE
Fix per-room judging and disable invalid BP save

### DIFF
--- a/app/debate/routes.py
+++ b/app/debate/routes.py
@@ -6,21 +6,29 @@ from app.models import Debate, SpeakerSlot, Score, BpRank
 from . import debate_bp
 
 
-def is_chair(user, debate_id):
-    slot = SpeakerSlot.query.filter_by(debate_id=debate_id, user_id=user.id, role='Judge-Chair').first()
-    return slot is not None
+def get_chair_slot(user, debate_id):
+    """Return chair slot for a user in a debate or None."""
+    return SpeakerSlot.query.filter_by(
+        debate_id=debate_id,
+        user_id=user.id,
+        role='Judge-Chair'
+    ).first()
 
 
 @debate_bp.route('/debate/<int:debate_id>/judging', methods=['GET', 'POST'])
 @login_required
 def judging(debate_id):
     debate = Debate.query.get_or_404(debate_id)
-    if not is_chair(current_user, debate_id):
+    chair_slot = get_chair_slot(current_user, debate_id)
+    if not chair_slot:
         flash('Only the chair judge can access this page.', 'danger')
         return redirect(url_for('main.debate_view', debate_id=debate_id))
 
+    room = chair_slot.room
+
     judges = SpeakerSlot.query.filter(
         SpeakerSlot.debate_id == debate_id,
+        SpeakerSlot.room == room,
         SpeakerSlot.role.startswith('Judge')
     ).all()
 
@@ -39,19 +47,38 @@ def judging(debate_id):
 
     speakers = SpeakerSlot.query.filter(
         SpeakerSlot.debate_id == debate_id,
+        SpeakerSlot.room == room,
         ~SpeakerSlot.role.startswith('Judge')
     ).all()
+    speaker_ids = [sp.user_id for sp in speakers]
+    judge_ids = [j.user_id for j in judges]
+
     if request.method == 'POST':
-        Score.query.filter_by(debate_id=debate_id).delete()
+        Score.query.filter(
+            Score.debate_id == debate_id,
+            Score.speaker_id.in_(speaker_ids),
+            Score.judge_id.in_(judge_ids)
+        ).delete(synchronize_session=False)
         for sp in speakers:
             for j in judges:
                 key = f'score_{sp.id}_{j.id}'
                 val = request.form.get(key)
                 if val:
-                    db.session.add(Score(debate_id=debate_id, speaker_id=sp.user_id,
-                                         judge_id=j.user_id, value=int(val)))
+                    db.session.add(Score(
+                        debate_id=debate_id,
+                        speaker_id=sp.user_id,
+                        judge_id=j.user_id,
+                        value=int(val)
+                    ))
         db.session.commit()
         flash('Scores saved.', 'success')
         return redirect(url_for('debate.judging', debate_id=debate_id))
-    scores = {(s.speaker_id, s.judge_id): s.value for s in Score.query.filter_by(debate_id=debate_id).all()}
+    scores = {
+        (s.speaker_id, s.judge_id): s.value
+        for s in Score.query.filter(
+            Score.debate_id == debate_id,
+            Score.speaker_id.in_(speaker_ids),
+            Score.judge_id.in_(judge_ids)
+        ).all()
+    }
     return render_template('debate/judging_opd.html', debate=debate, judges=judges, speakers=speakers, scores=scores)

--- a/app/templates/debate/judging_bp.html
+++ b/app/templates/debate/judging_bp.html
@@ -15,7 +15,7 @@
     </tbody>
   </table>
   <p id="rank-warning" class="text-danger d-none">Each rank must be used once.</p>
-  <button type="submit" class="btn btn-primary">Save</button>
+  <button id="save-btn" type="submit" class="btn btn-primary">Save</button>
 </form>
 {% endblock %}
 {% block extra_js %}
@@ -25,6 +25,7 @@ function check() {
   const used = vals.filter(v=>v);
   const ok = new Set(used).size===4 && used.length===4;
   document.getElementById('rank-warning').classList.toggle('d-none', ok);
+  document.getElementById('save-btn').disabled = !ok;
 }
 document.querySelectorAll('.rank-input').forEach(i=>i.addEventListener('input', check));
 check();


### PR DESCRIPTION
## Summary
- restrict OPD judging to the chair's assigned room
- retain scores of the other room when saving
- disable the BP ranking save button until ranks 1-4 are unique

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684b53a03848833081c03eb418f94a93