### PR TITLE
Implement dynamic debate style

### DIFF
--- a/app/logic/assign.py
+++ b/app/logic/assign.py
@@ -19,6 +19,8 @@ def assign_speakers(debate, users, max_rooms=2):
     elif debate.style == "BP":
         split_threshold = 18
         helper = assign_bp_single_room
+    elif debate.style == "Dynamic":
+        return assign_dynamic(debate, users)
     else:
         return False, f"Unknown debate style: {debate.style}"
 
@@ -276,4 +278,18 @@ def assign_bp_single_room(debate, users, room=1):
             db.session.add(slot)
     db.session.commit()
     return True, "BP speaker assignment complete."
+
+
+def assign_dynamic(debate, users):
+    """Very simple dynamic assignment heuristic.
+    Chooses OPD for small groups and BP for larger ones."""
+    if len(users) <= 7:
+        return assign_opd_single_room(debate, users, room=1)
+    elif len(users) <= 9:
+        return assign_bp_single_room(debate, users, room=1)
+    else:
+        mid = len(users) // 2
+        ok1, msg1 = assign_opd_single_room(debate, users[:mid], room=1)
+        ok2, msg2 = assign_bp_single_room(debate, users[mid:], room=2)
+        return ok1 and ok2, f"Dynamic: {msg1}; {msg2}"
 

--- a/app/models.py
+++ b/app/models.py
@@ -60,7 +60,10 @@ class User(UserMixin, db.Model):
 class Debate(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     title = db.Column(db.String(140), nullable=False)
-    style = db.Column(db.Enum('OPD', 'BP', name='debate_style'), nullable=False)
+    style = db.Column(
+        db.Enum('OPD', 'BP', 'Dynamic', name='debate_style'),
+        nullable=False
+    )
     voting_open = db.Column(db.Boolean, default=True)
 
     # Relationship: which topics belong to this debate?

--- a/app/templates/admin/create_debate.html
+++ b/app/templates/admin/create_debate.html
@@ -15,6 +15,7 @@
                 <option value="">Select style</option>
                 <option value="OPD">OPD</option>
                 <option value="BP">BP</option>
+                <option value="Dynamic">Dynamic</option>
             </select>
         </div>
         <button type="submit" class="btn btn-success">Create</button>

--- a/app/templates/admin/dashboard.html
+++ b/app/templates/admin/dashboard.html
@@ -36,9 +36,13 @@
             <a href="{{ url_for('admin.toggle_voting', debate_id=debate.id) }}" class="btn btn-outline-warning btn-sm flex-fill flex-md-grow-0">
               {% if debate.voting_open %}Close Voting{% else %}Open Voting{% endif %}
             </a>
+            {% if debate.style == 'Dynamic' %}
+            <a href="{{ url_for('admin.dynamic_plan', debate_id=debate.id) }}" class="btn btn-info btn-sm flex-fill flex-md-grow-0">Plan Dynamic Rooms</a>
+            {% else %}
             <form action="{{ url_for('admin.run_assign', debate_id=debate.id) }}" method="post" style="display:inline;">
               <button class="btn btn-info btn-sm flex-fill flex-md-grow-0">Assign Speakers</button>
             </form>
+            {% endif %}
           </div>
 
           <p class="mb-1"><strong>Voters:</strong> {{ voter_counts[debate.id] }}</p>

--- a/app/templates/admin/dynamic_plan.html
+++ b/app/templates/admin/dynamic_plan.html
@@ -1,0 +1,28 @@
+{% extends "base.html" %}
+{% block title %}Dynamic Plan{% endblock %}
+{% block content %}
+<div class="container my-4">
+  <h2 class="mb-3">Dynamic Plan for {{ debate.title }}</h2>
+  <h4>Active Participants Grouped by Skill</h4>
+  <ul>
+  {% for skill, users in groups.items() %}
+    <li><strong>{{ skill }} ({{ users|length }})</strong>: 
+        {% for u in users %}{{ u.username }}{% if not loop.last %}, {% endif %}{% endfor %}
+    </li>
+  {% endfor %}
+  </ul>
+  <h4 class="mt-4">Possible Scenarios</h4>
+  <ul>
+  {% for sc in scenarios %}
+    <li>
+      {% if sc.type == 'Mixed' %}
+        {{ sc.rooms_opd }} OPD rooms and {{ sc.rooms_bp }} BP rooms
+      {% else %}
+        {{ sc.rooms }} {{ sc.type }} rooms
+      {% endif %}
+    </li>
+  {% endfor %}
+  </ul>
+  <a href="{{ url_for('admin.admin_dashboard') }}" class="btn btn-secondary mt-3">Back</a>
+</div>
+{% endblock %}

--- a/app/templates/admin/edit_debate.html
+++ b/app/templates/admin/edit_debate.html
@@ -9,6 +9,7 @@
     <select name="style">
         <option value="OPD" {% if debate.style == "OPD" %}selected{% endif %}>OPD</option>
         <option value="BP" {% if debate.style == "BP" %}selected{% endif %}>BP</option>
+        <option value="Dynamic" {% if debate.style == "Dynamic" %}selected{% endif %}>Dynamic</option>
     </select><br>
     <input type="submit" value="Save">
 </form>


### PR DESCRIPTION
## Summary
- allow `Dynamic` as a debate style
- provide dynamic room planning page in admin panel
- show planning link for dynamic debates
- basic heuristic for assigning dynamic debates

## Testing
- `pytest`
- `flake8 app` *(fails: E/W errors)*

------
https://chatgpt.com/codex/tasks/task_e_684b56624e488330bac4caea83ec0e6f