### PR TITLE
Enable fallback chairs in dynamic room planning

### DIFF
--- a/app/templates/admin/dynamic_plan.html
+++ b/app/templates/admin/dynamic_plan.html
@@ -19,6 +19,7 @@
       <input class="form-check-input" type="radio" name="scenario" id="sc{{ loop.index }}" value="{{ sc.id }}" {% if loop.first %}checked{% endif %}>
       <label class="form-check-label" for="sc{{ loop.index }}">
         {{ sc.desc }}
+        {% if not sc.safe %}<span class="badge bg-warning text-dark ms-2">Unsafe</span>{% endif %}
       </label>
     </div>
     {% endfor %}


### PR DESCRIPTION
## Summary
- allow dynamic planning to fall back to wings/non‑first timers as chairs
- label scenarios using fallback chairs as unsafe
- show an Unsafe badge on dynamic planning page

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b5cf3d6308330a411eb542a66e3bd