### PR TITLE
Enable dynamic scenario generation

### DIFF
--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -1,6 +1,7 @@
 from flask import render_template, redirect, url_for, flash, request, jsonify
 from flask_login import login_required, current_user
 from sqlalchemy import distinct
+import itertools
 from app.models import Debate, Topic, Vote, User
 from app.extensions import db
 from app.logic.assign import assign_speakers, _compute_room_counts
@@ -249,23 +250,57 @@ def dynamic_plan(debate_id):
 
     total = len(users)
     chair_count = sum(1 for u in users if u.judge_skill == 'Chair')
-
-    scenario_defs = {
-        'opd_bp': [('OPD', 7, 12), ('BP', 9, 11)],
-        'opd_opd': [('OPD', 7, 12), ('OPD', 7, 12)],
-        'bp_bp': [('BP', 9, 11), ('BP', 9, 11)],
-    }
-    descriptions = {
-        'opd_bp': '1 OPD room and 1 BP room',
-        'opd_opd': 'Two OPD rooms',
-        'bp_bp': 'Two BP rooms',
-    }
+    def eligible_chair(u):
+        if getattr(u, 'judge_skill', '') == 'Chair':
+            return True
+        if getattr(u, 'judge_skill', '') == 'Wing' and getattr(u, 'debate_skill', '') != 'First Timer':
+            return True
+        return getattr(u, 'debate_skill', '') != 'First Timer'
+    fallback_chair_count = sum(1 for u in users if eligible_chair(u))
 
     scenarios = []
-    for key, spec in scenario_defs.items():
-        counts = _compute_room_counts(total, [(s[1], s[2]) for s in spec])
-        if counts and chair_count >= len(spec):
-            scenarios.append({'id': key, 'desc': descriptions[key]})
+    room_types = {'O': ('OPD', 7, 12), 'B': ('BP', 9, 11)}
+
+    max_rooms = min(5, total // 7) if total else 1
+
+    def opd_breakdown(n):
+        extra = max(n - 7, 0)
+        wing = 1 if extra > 0 else 0
+        free = min(max(n - 8, 0), 3)
+        speakers = 6 + free
+        judges = n - speakers
+        return f'{speakers} speakers, {judges} judges'
+
+    def bp_breakdown(n):
+        wings = min(max(n - 9, 0), 3)
+        speakers = 8
+        judges = 1 + wings
+        return f'{speakers} speakers, {judges} judges'
+
+    for num_rooms in range(1, max_rooms + 1):
+        for combo in itertools.product('OB', repeat=num_rooms):
+            spec = [room_types[c] for c in combo]
+            counts = _compute_room_counts(total, [(s[1], s[2]) for s in spec])
+            if not counts:
+                continue
+            safe = chair_count >= num_rooms
+            if not safe and fallback_chair_count < num_rooms:
+                continue
+            desc = ' + '.join(room_types[c][0] for c in combo)
+            if not safe:
+                desc += ' (unsafe - using fallback Chairs)'
+            breakdown = []
+            for c, count in zip(combo, counts):
+                if c == 'O':
+                    breakdown.append(opd_breakdown(count))
+                else:
+                    breakdown.append(bp_breakdown(count))
+            scenarios.append({
+                'id': '-'.join(c for c in combo),
+                'desc': desc,
+                'safe': safe,
+                'breakdown': breakdown
+            })
 
     return render_template('admin/dynamic_plan.html',
                            debate=debate,

--- a/app/templates/admin/dynamic_plan.html
+++ b/app/templates/admin/dynamic_plan.html
@@ -19,7 +19,13 @@
       <input class="form-check-input" type="radio" name="scenario" id="sc{{ loop.index }}" value="{{ sc.id }}" {% if loop.first %}checked{% endif %}>
       <label class="form-check-label" for="sc{{ loop.index }}">
         {{ sc.desc }}
+        {% if not sc.safe %}<span class="badge bg-warning text-dark ms-2">Unsafe</span>{% endif %}
       </label>
+      <ul class="ms-4">
+        {% for item in sc.breakdown %}
+          <li>Room {{ loop.index }}: {{ item }}</li>
+        {% endfor %}
+      </ul>
     </div>
     {% endfor %}
     <button type="submit" class="btn btn-primary mt-3">Assign Speakers</button>


### PR DESCRIPTION
## Summary
- build dynamic planning scenarios using up to 5 rooms
- compute participant breakdown per room and show in admin view
- parse new scenario IDs in assignment logic

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684b5cf3d6308330a411eb542a66e3bd