### PR TITLE
Add live debate and assignment updates

### DIFF
--- a/app/static/js/dashboard.js
+++ b/app/static/js/dashboard.js
@@ -1,5 +1,89 @@
 const socket = io();
 
+function populateTopics() {
+  const debateId = window.currentDebateId;
+  if (!debateId) return;
+  fetch(`/debate/${debateId}/topics_json`)
+    .then(r => r.json())
+    .then(data => {
+      const menu = document.getElementById('voteDropdownMenu');
+      if (!menu) return;
+      menu.innerHTML = '';
+      data.topics.forEach(t => {
+        const li = document.createElement('li');
+        const a = document.createElement('a');
+        a.classList.add('dropdown-item');
+        a.href = '#';
+        a.dataset.topicId = t.id;
+        a.textContent = t.text;
+        li.appendChild(a);
+        menu.appendChild(li);
+      });
+    });
+}
+
+function populateAssignments() {
+  const debateId = window.currentDebateId;
+  if (!debateId) return Promise.resolve();
+  return fetch(`/debate/${debateId}/assignments_json`)
+    .then(r => r.json())
+    .then(data => {
+      const menu = document.getElementById('speakerDropdownMenu');
+      if (!menu) return;
+      menu.innerHTML = '';
+      data.assignments.forEach(a => {
+        const li = document.createElement('li');
+        li.classList.add('dropdown-item-text');
+        li.textContent = `${a.role} - ${a.username} (Room ${a.room})`;
+        menu.appendChild(li);
+      });
+      const divider = document.createElement('li');
+      divider.innerHTML = '<hr class="dropdown-divider">';
+      menu.appendChild(divider);
+      const linkLi = document.createElement('li');
+      const link = document.createElement('a');
+      link.classList.add('dropdown-item');
+      link.href = window.graphicUrl;
+      link.textContent = 'Open Graphic';
+      linkLi.appendChild(link);
+      menu.appendChild(linkLi);
+    });
+}
+
+function castVote(topicId) {
+  const debateId = window.currentDebateId;
+  fetch(`/debate/${debateId}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({ topic_id: topicId })
+  }).then(() => {
+    const dropdown = bootstrap.Dropdown.getOrCreateInstance(document.getElementById('voteDropdown'));
+    dropdown.hide();
+  });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  if (window.currentDebateId && (window.votingOpen === true || window.votingOpen === "true")) {
+    populateTopics();
+  } else {
+    const cont = document.getElementById('voteDropdownContainer');
+    if (cont) cont.style.display = 'none';
+  }
+  if (window.currentDebateId && (window.assignmentsComplete === true || window.assignmentsComplete === "true")) {
+    populateAssignments();
+  }
+
+  const voteMenu = document.getElementById('voteDropdownMenu');
+  if (voteMenu) {
+    voteMenu.addEventListener('click', e => {
+      const target = e.target.closest('[data-topic-id]');
+      if (!target) return;
+      e.preventDefault();
+      castVote(target.dataset.topicId);
+    });
+  }
+});
+
 socket.on('vote_update', data => {
   const currentDebateId = window.currentDebateId;
   if (!currentDebateId || data.debate_id !== currentDebateId) return;
@@ -21,5 +105,25 @@ socket.on('vote_update', data => {
     } else if (el.textContent.includes('%')) {
       el.textContent = percent + '%';
     }
+  });
+});
+
+socket.on('debate_status', data => {
+  if (data.debate_id !== window.currentDebateId) return;
+  const cont = document.getElementById('voteDropdownContainer');
+  if (!cont) return;
+  if (data.voting_open) {
+    cont.style.display = 'block';
+    populateTopics();
+  } else {
+    cont.style.display = 'none';
+  }
+});
+
+socket.on('assignments_ready', data => {
+  if (data.debate_id !== window.currentDebateId) return;
+  populateAssignments().then(() => {
+    const dd = bootstrap.Dropdown.getOrCreateInstance(document.getElementById('speakerDropdown'));
+    dd.show();
   });
 });

--- a/app/templates/main/dashboard.html
+++ b/app/templates/main/dashboard.html
@@ -8,6 +8,9 @@
 {% block content %}
 <script>
   window.currentDebateId = {{ current_debate.id if current_debate else 'null' }};
+  window.votingOpen = {{ 'true' if current_debate and current_debate.voting_open else 'false' }};
+  window.assignmentsComplete = {{ 'true' if current_debate and current_debate.assignment_complete else 'false' }};
+  window.graphicUrl = "{{ url_for('main.debate_graphic', debate_id=current_debate.id) if current_debate else '' }}";
 </script>
 
 <div class="container my-4">
@@ -42,11 +45,19 @@
         <p class="mt-2 fw-bold text-primary">You are {{ user_role }}</p>
       {% endif %}
       <div class="d-grid gap-2 mt-3">
-        <a href="{{ url_for('main.debate_view', debate_id=current_debate.id) }}"
-           class="btn btn-primary">Vote Now</a>
+        <div id="voteDropdownContainer" class="dropdown">
+          <button class="btn btn-primary dropdown-toggle" type="button" id="voteDropdown" data-bs-toggle="dropdown" aria-expanded="false">
+            Vote Now
+          </button>
+          <ul class="dropdown-menu" id="voteDropdownMenu"></ul>
+        </div>
         {% if current_debate.assignment_complete %}
-          <a href="{{ url_for('main.debate_graphic', debate_id=current_debate.id) }}"
-             class="btn btn-outline-secondary">View Speakers</a>
+        <div class="dropdown">
+          <button class="btn btn-outline-secondary dropdown-toggle" type="button" id="speakerDropdown" data-bs-toggle="dropdown" aria-expanded="false">
+            View Speakers
+          </button>
+          <ul class="dropdown-menu" id="speakerDropdownMenu"></ul>
+        </div>
         {% endif %}
       </div>
       {% else %}


### PR DESCRIPTION
## Summary
- emit `debate_status` and `assignments_ready` websocket events
- expose new JSON APIs for topics and assignments
- add voting and speaker dropdowns on dashboard
- update dashboard.js for live updates and dropdown voting

## Testing
- `python -m py_compile app/admin/routes.py app/main/routes.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bcb29048083308222829a5c340493