### PR TITLE
Add inline debate layout display

### DIFF
--- a/app/static/css/dashboard.css
+++ b/app/static/css/dashboard.css
@@ -15,8 +15,6 @@
   margin: 0 auto 1rem auto;
 }
 
-#graphicContainer iframe {
+#graphicContainer {
   width: 100%;
-  height: 400px;
-  border: 0;
 }

--- a/app/templates/main/dashboard.html
+++ b/app/templates/main/dashboard.html
@@ -11,6 +11,9 @@
   window.votingOpen = {{ 'true' if current_debate and current_debate.voting_open else 'false' }};
   window.assignmentsComplete = {{ 'true' if current_debate and current_debate.assignment_complete else 'false' }};
   window.graphicUrl = "{{ url_for('main.debate_graphic', debate_id=current_debate.id) if current_debate else '' }}";
+  window.currentDebateStyle = "{{ current_debate.style if current_debate else '' }}";
+  window.currentUserId = {{ current_user.id }};
+  window.userHasSlot = {{ 'true' if user_role else 'false' }};
 </script>
 
 <div class="container my-4">


### PR DESCRIPTION
## Summary
- build front-end layout from assignments_json
- expose debate style, user id and slot info on the dashboard page
- display the layout inline when assignments are ready
- simplify dashboard CSS

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684bd138fdfc8330a9fc2b69a1c03584