### PR TITLE
Ensure dashboard loads graphic css

### DIFF
--- a/app/templates/main/dashboard.html
+++ b/app/templates/main/dashboard.html
@@ -3,6 +3,7 @@
 
 {% block extra_head %}
   <link rel="stylesheet" href="{{ url_for('static', filename='css/dashboard.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/graphic.css') }}">
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
## Summary
- include `graphic.css` in dashboard page

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684be5ec478c83309b512a7cf9f6901c