### PR TITLE
Move debate layout styles to graphic.css

### DIFF
--- a/app/static/css/graphic.css
+++ b/app/static/css/graphic.css
@@ -1,8 +1,8 @@
 /* typography & base */
 .diagram-opd,
-.diagram-bp {display:flex;flex-wrap:wrap;gap:.75rem}
+.diagram-bp {display:flex;flex-wrap:wrap;flex-direction:column;gap:1rem;margin-bottom:2rem}
 .bench      {flex:1 1 100%;padding:1rem;border-radius:.5rem}
-.free-area  {flex:1 1 100%;text-align:center}
+.free-area  {flex:1 1 0;text-align:center;min-width:150px;background:#f8f9fa;border-radius:.5rem;padding:.75rem;margin-bottom:1rem}
 .gov-bench  {background:#e7f3ff}
 .opp-bench  {background:#ffe7e7}
 .bench-title{font-weight:600;margin-bottom:.5rem}
@@ -14,10 +14,16 @@
   border-radius:.5rem;text-align:center}
 .bp-title{font-weight:600;margin-bottom:.25rem}
 .placeholder{opacity:.5;font-size:.85rem}
+.judges-row{display:flex;gap:.5rem;flex-wrap:wrap;overflow-x:auto}
 .judges-row .role-badge{background:#cfe2ff}
 
 @media (min-width:768px){
-  .bench{flex:1 1 calc(50% - .75rem)}
+  .bench{flex:1 1 calc(50% - .75rem);min-width:180px}
+  .bp-team-card{flex:1 1 0;min-width:180px}
   .free-area{flex:1 1 calc(100% - 1.5rem);order:-1}
-  .diagram-opd{justify-content:space-between}
+  .diagram-opd{justify-content:space-between;flex-direction:row;align-items:stretch}
+  .diagram-bp{flex-direction:row;justify-content:space-between;align-items:flex-start}
+}
+@media (max-width:767px){
+  .bench,.bp-team-card,.free-area{min-width:0}
 }

--- a/app/templates/main/graphic.html
+++ b/app/templates/main/graphic.html
@@ -3,50 +3,7 @@
 
 {% block extra_head %}
 <link rel="stylesheet" href="{{ url_for('static', filename='css/graphic.css') }}">
-<style>
-  /* Additional responsive tweaks for debate diagrams */
-  .diagram-opd, .diagram-bp {
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-    margin-bottom: 2rem;
-  }
-  @media (min-width: 768px) {
-    .diagram-opd {
-      flex-direction: row;
-      justify-content: space-between;
-      align-items: stretch;
-    }
-    .diagram-bp {
-      flex-direction: row;
-      justify-content: space-between;
-      align-items: flex-start;
-    }
-    .bench, .bp-team-card {
-      flex: 1 1 0;
-      min-width: 180px;
-    }
-  }
-  .free-area {
-    flex: 1 1 0;
-    min-width: 150px;
-    background: #f8f9fa;
-    border-radius: 0.5rem;
-    padding: 0.75rem;
-    margin-bottom: 1rem;
-  }
-  .judges-row {
-    display: flex;
-    gap: 0.5rem;
-    flex-wrap: wrap;
-    overflow-x: auto;
-  }
-  @media (max-width: 767px) {
-    .bench, .bp-team-card, .free-area {
-      min-width: 0;
-    }
-  }
-</style>
+
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
## Summary
- consolidate inline diagram styles into `graphic.css`
- remove redundant `<style>` block from `graphic.html`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684be8a356b0833086915ac8234cd148