### PR TITLE
Improve dynamic debate updates

### DIFF
--- a/app/static/js/dashboard.js
+++ b/app/static/js/dashboard.js
@@ -254,18 +254,19 @@ function updateCurrentDebate(data) {
     if (badge) badge.remove();
   }
 
-  const progress = document.querySelector('.current-debate .progress');
-  const progressBar = document.querySelector('.current-debate .progress-bar');
-  const infoTexts = document.querySelectorAll('.current-debate .d-flex small.text-muted');
-  if (data) {
-    if (progress && progressBar) {
-      progressBar.style.width = data.vote_percent + '%';
-      progressBar.setAttribute('aria-valuenow', data.vote_percent);
-      progressBar.textContent = `${data.votes_cast}/${data.votes_total}`;
-    }
-    if (infoTexts.length >= 2) {
-      infoTexts[0].textContent = `${data.votes_cast}/${data.votes_total} have voted`;
-      infoTexts[1].textContent = data.vote_percent + '%';
+  const progress = document.getElementById('voteProgress');
+  const progressBar = document.querySelector('#voteProgress .progress-bar');
+  const infoWrap = document.getElementById('voteInfo');
+  if (progress) progress.style.display = data ? 'block' : 'none';
+  if (infoWrap) infoWrap.style.display = data ? 'flex' : 'none';
+  if (data && progressBar && infoWrap) {
+    progressBar.style.width = data.vote_percent + '%';
+    progressBar.setAttribute('aria-valuenow', data.vote_percent);
+    progressBar.textContent = `${data.votes_cast}/${data.votes_total}`;
+    const smalls = infoWrap.querySelectorAll('small.text-muted');
+    if (smalls.length >= 2) {
+      smalls[0].textContent = `${data.votes_cast}/${data.votes_total} have voted`;
+      smalls[1].textContent = data.vote_percent + '%';
     }
   }
 
@@ -277,6 +278,11 @@ function updateCurrentDebate(data) {
     } else {
       roleEl.style.display = 'none';
     }
+  }
+
+  const noDebateMsg = document.getElementById('noDebateMessage');
+  if (noDebateMsg) {
+    noDebateMsg.style.display = data ? 'none' : 'block';
   }
 
   window.currentDebateId = data ? data.id : null;

--- a/app/templates/main/dashboard.html
+++ b/app/templates/main/dashboard.html
@@ -32,28 +32,23 @@
           <span class="badge bg-info">{{ current_debate.style }}</span>
         {% endif %}
       </h4>
-      {% if current_debate %}
-      <div class="progress my-2" style="height: 1.25rem;">
+      <div id="voteProgress" class="progress my-2" style="height: 1.25rem;{% if not current_debate %} display:none;{% endif %}">
         <div class="progress-bar bg-success"
              style="width: {{ vote_percent or 0 }}%;"
              aria-valuenow="{{ vote_percent or 0 }}" aria-valuemin="0" aria-valuemax="100">
           {{ votes_cast or 0 }}/{{ votes_total or 0 }}
         </div>
       </div>
-      <div class="d-flex justify-content-between align-items-center mb-2">
+      <div id="voteInfo" class="d-flex justify-content-between align-items-center mb-2"{% if not current_debate %} style="display:none"{% endif %}>
         <small class="text-muted">{{ votes_cast or 0 }}/{{ votes_total or 0 }} have voted</small>
         <small class="text-muted">{{ vote_percent or 0 }}%</small>
       </div>
-      {% if user_role %}
-        <p class="mt-2 fw-bold text-primary">You are {{ user_role }}</p>
-      {% endif %}
+      <p id="userRoleText" class="mt-2 fw-bold text-primary"{% if not user_role %} style="display:none"{% endif %}>You are {{ user_role }}</p>
       <div class="mt-3">
-        <div id="voteBoxContainer" class="card p-3 vote-box"></div>
-        <div id="graphicContainer" class="mt-3" style="display:none"></div>
+        <div id="voteBoxContainer" class="card p-3 vote-box"{% if not current_debate or not current_debate.voting_open %} style="display:none"{% endif %}></div>
+        <div id="graphicContainer" class="mt-3"{% if not current_debate or not current_debate.assignment_complete or not user_role %} style="display:none"{% endif %}></div>
       </div>
-      {% else %}
-        <p class="text-muted">No active debate at the moment.</p>
-      {% endif %}
+      <p id="noDebateMessage" class="text-muted"{% if current_debate %} style="display:none"{% endif %}>No active debate at the moment.</p>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
- keep vote box and assignment graphic always present
- toggle progress bars and role text dynamically
- update JS to show/hide these elements when current debate changes

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684bf3ef298883308052c436c806f5ae