### PR TITLE
Add active column and set default for debates

### DIFF
--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -55,7 +55,7 @@ def create_debate():
         if not title or style not in ['OPD', 'BP', 'Dynamic']:
             flash('Please fill all fields correctly.', 'danger')
             return redirect(url_for('admin.create_debate'))
-        debate = Debate(title=title, style=style)
+        debate = Debate(title=title, style=style, active=False)
         db.session.add(debate)
         db.session.commit()
         flash('Debate created!', 'success')

--- a/app/models.py
+++ b/app/models.py
@@ -65,6 +65,7 @@ class Debate(db.Model):
         nullable=False
     )
     voting_open = db.Column(db.Boolean, default=True)
+    active = db.Column(db.Boolean, default=False)
 
     # Relationship: which topics belong to this debate?
     topics = db.relationship('Topic', back_populates='debate', cascade='all, delete-orphan')

--- a/migrations/versions/19b5a7cb2c59_add_active_column_to_debate.py
+++ b/migrations/versions/19b5a7cb2c59_add_active_column_to_debate.py
@@ -1,0 +1,26 @@
+"""add active column to debate
+
+Revision ID: 19b5a7cb2c59
+Revises: 0d2e6c501f2d
+Create Date: 2025-06-13 10:53:04.065910
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '19b5a7cb2c59'
+down_revision = '0d2e6c501f2d'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('debate', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('active', sa.Boolean(), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table('debate', schema=None) as batch_op:
+        batch_op.drop_column('active')


### PR DESCRIPTION
## Summary
- add an `active` field to the `Debate` model
- create Alembic migration for the new column
- default new debates to inactive when created

## Testing
- `flask db upgrade`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c02b09ff0833096b441f194fcc0d0