### PR TITLE
Add admin route to toggle debate active state

### DIFF
--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -99,6 +99,22 @@ def toggle_voting(debate_id):
     status = "opened" if debate.voting_open else "closed"
     flash(f'Voting {status} for {debate.title}.', 'info')
     return redirect(url_for('admin.admin_dashboard'))
+
+# Toggle active status
+@admin_bp.route('/admin/<int:debate_id>/toggle_active')
+@login_required
+@admin_required
+def toggle_active(debate_id):
+    debate = Debate.query.get_or_404(debate_id)
+    debate.active = not debate.active
+    db.session.commit()
+    socketio.emit('debate_list_update', {
+        'debate_id': debate_id,
+        'active': debate.active
+    })
+    status = "activated" if debate.active else "deactivated"
+    flash(f'Debate {status}.', 'info')
+    return redirect(url_for('admin.admin_dashboard'))
     
 @admin_bp.route('/admin/debate/<int:debate_id>/vote_stats')
 @login_required

--- a/app/templates/admin/dashboard.html
+++ b/app/templates/admin/dashboard.html
@@ -36,6 +36,9 @@
             <a href="{{ url_for('admin.toggle_voting', debate_id=debate.id) }}" class="btn btn-outline-warning btn-sm flex-fill flex-md-grow-0">
               {% if debate.voting_open %}Close Voting{% else %}Open Voting{% endif %}
             </a>
+            <a href="{{ url_for('admin.toggle_active', debate_id=debate.id) }}" class="btn btn-outline-secondary btn-sm flex-fill flex-md-grow-0">
+              {% if debate.active %}Set Inactive{% else %}Set Active{% endif %}
+            </a>
             {% if debate.style == 'Dynamic' %}
             <a href="{{ url_for('admin.dynamic_plan', debate_id=debate.id) }}" class="btn btn-info btn-sm flex-fill flex-md-grow-0">Plan Dynamic Rooms</a>
             {% else %}


### PR DESCRIPTION
## Summary
- implement `/admin/<int:debate_id>/toggle_active` route
- show "Set Active/Set Inactive" button on admin dashboard

## Testing
- `pytest -q`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c0565ba1c8330aa7f973035440e9b