### PR TITLE
Update debates_json and dashboard logic

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -87,7 +87,12 @@ def dashboard_debates_json():
     upcoming_debates = [d for d in debates if not d.active and not d.assignment_complete]
 
     def serialize(d):
-        return {'id': d.id, 'title': d.title, 'style': d.style} if d else None
+        return {
+            'id': d.id,
+            'title': d.title,
+            'style': d.style,
+            'active': d.active,
+        } if d else None
 
     def serialize_current(d):
         if not d:
@@ -118,6 +123,7 @@ def dashboard_debates_json():
             'id': d.id,
             'title': d.title,
             'style': d.style,
+            'active': d.active,
             'voting_open': d.voting_open,
             'assignment_complete': d.assignment_complete,
             'user_role': user_role,

--- a/app/static/js/dashboard.js
+++ b/app/static/js/dashboard.js
@@ -347,14 +347,22 @@ function updateDebateLists(data) {
   const pastCont = document.getElementById('past');
   const upcomingCont = document.getElementById('upcoming');
   if (!activeCont || !pastCont || !upcomingCont) return;
-  buildDebateCards(activeCont, data.active_debates, 'bg-info');
-  buildDebateCards(pastCont, data.past_debates, 'bg-secondary');
-  buildDebateCards(upcomingCont, data.upcoming_debates, 'bg-warning text-dark');
-  const openCount = (data.current_debate ? 1 : 0) + data.active_debates.length;
+
+  const activeDebates = data.active_debates.filter(d => d.active);
+  const pastDebates = data.past_debates.filter(d => !d.active && d.assignment_complete);
+  const upcomingDebates = data.upcoming_debates.filter(d => !d.active && !d.assignment_complete);
+
+  buildDebateCards(activeCont, activeDebates, 'bg-info');
+  buildDebateCards(pastCont, pastDebates, 'bg-secondary');
+  buildDebateCards(upcomingCont, upcomingDebates, 'bg-warning text-dark');
+
+  const openCount = (data.current_debate && data.current_debate.active ? 1 : 0) + activeDebates.length;
   if (openCount === 1) {
-    window.currentDebateId = data.current_debate
-      ? data.current_debate.id
-      : data.active_debates[0].id;
+    if (data.current_debate && data.current_debate.active) {
+      window.currentDebateId = data.current_debate.id;
+    } else {
+      window.currentDebateId = activeDebates[0].id;
+    }
   } else {
     window.currentDebateId = null;
   }


### PR DESCRIPTION
## Summary
- include `active` flag in `dashboard_debates_json`
- filter debates client-side based on active flag and use it when deciding current debate

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684c0727f0dc8330b1a598fcfaeae3af