### PR TITLE
Fix dynamic updates to use active debates

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -61,8 +61,8 @@ def create_app(config_file=None):
             current_user.last_seen = datetime.utcnow()
             db.session.commit()
             
-            # --- WebSocket live update for open debates ---
-            open_debates = Debate.query.filter_by(voting_open=True).all()
+            # --- WebSocket live update for active debates ---
+            open_debates = Debate.query.filter_by(active=True).all()
             now = datetime.utcnow()
             ten_minutes_ago = now - timedelta(minutes=10)
 


### PR DESCRIPTION
## Summary
- continue sending vote updates even when voting closes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c0818b0d88330b3a5a269992ff788