### PR TITLE
Handle active room server-side

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -301,11 +301,16 @@ def debate_graphic(debate_id):
         else:
             room_styles[room] = debate.style
 
+    active_room = request.args.get('room', type=int)
+    if not active_room:
+        active_room = my_slot.room if my_slot else sorted(slots_by_room)[0]
+
     return render_template(
         'main/graphic.html',
         debate=debate,
         slots_by_room=slots_by_room,
         room_styles=room_styles,
+        active_room=active_room,
         my_slot=my_slot,
         user=current_user,
     )

--- a/app/templates/main/graphic.html
+++ b/app/templates/main/graphic.html
@@ -6,7 +6,6 @@
 
 {% endblock %}
 
-{% set active_room = request.args.get('room', type=int) %}
 {% block content %}
 <div class="container py-3">
 
@@ -25,7 +24,7 @@
       <ul class="nav nav-tabs flex-nowrap overflow-auto">
         {% for room in slots_by_room.keys()|sort %}
           <li class="nav-item">
-            <a class="nav-link {% if room == active_room|default(my_slot.room) %}active{% endif %}"
+            <a class="nav-link {% if room == active_room %}active{% endif %}"
                href="{{ url_for('main.debate_graphic', debate_id=debate.id) }}?room={{ room }}">
               Room {{ room }} ({{ room_styles[room] }})
             </a>
@@ -37,7 +36,7 @@
       <select class="form-select" onchange="location = this.value;">
         {% for room in slots_by_room.keys()|sort %}
           <option value="{{ url_for('main.debate_graphic', debate_id=debate.id) }}?room={{ room }}"
-            {% if room == active_room|default(my_slot.room) %}selected{% endif %}>
+            {% if room == active_room %}selected{% endif %}>
             Room {{ room }} ({{ room_styles[room] }})
           </option>
         {% endfor %}
@@ -45,7 +44,7 @@
     </div>
   {% endif %}
 
-  {% set room = active_room|default(my_slot.room if my_slot else slots_by_room.keys()|list|first) %}
+  {% set room = active_room %}
   {% set slots = slots_by_room[room] %}
 
   {% if room_styles[room] == "OPD" %}


### PR DESCRIPTION
## Summary
- determine the active debate room in the view instead of Jinja
- simplify template logic by relying on `active_room` from the route

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- manual verification using a Flask test client to fetch the debate graphic page

------
https://chatgpt.com/codex/tasks/task_e_684c2728a304833084a01e38918efbcc