### PR TITLE
Fix dynamic assignment completion flag

### DIFF
--- a/app/logic/assign.py
+++ b/app/logic/assign.py
@@ -383,5 +383,8 @@ def assign_dynamic(debate, users, scenario=None):
     if unsafe:
         messages.append('Fallback Chairs were used')
 
+    if success:
+        debate.assignment_complete = True
+        db.session.commit()
     return success, ' | '.join(messages)
 


### PR DESCRIPTION
## Summary
- set `assignment_complete` after dynamic assignment succeeds

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684c2b2a6d648330a32012eac880027a