### PR TITLE
Add centralized configuration and update startup flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,20 @@
 5. Run the app:
     - `python run.py`
 
+## Configuration
+
+These settings can be provided via environment variables or by modifying
+`config.py`:
+
+- **SECRET_KEY** - Flask secret key. Default: `dev`.
+- **SQLALCHEMY_DATABASE_URI** - database connection string.
+  Default: `sqlite:///debate_app.db`.
+- **SQLALCHEMY_TRACK_MODIFICATIONS** - set to `true` to enable change
+  tracking. Default: `False`.
+- **CORS_ALLOWED_ORIGINS** - origins allowed for CORS and SocketIO.
+  Provide a comma-separated list (e.g. `https://example.com`). Default: `*`.
+- **PORT** - port used when running `python run.py`. Default: `5000`.
+
 ## 🚀 Production Deployment with uWSGI
 
 To run the app in a production environment using **uWSGI**, follow these steps:

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,6 +1,7 @@
 # app/__init__.py
 from datetime import datetime, timedelta
 from flask import Flask, request, redirect, url_for
+from config import Config
 from .extensions import db, login_manager, migrate
 from .models import Debate, Topic, Vote, User
 from flask_login import current_user
@@ -11,18 +12,19 @@ socketio = SocketIO()  # Create the SocketIO object globally
 
 def create_app(config_file=None):
     app = Flask(__name__)
-    
-    socketio.init_app(app)
-    
+
+    # Load configuration
+    app.config.from_object(Config)
+    if config_file:
+        app.config.from_pyfile(config_file)
+
+    # Initialize SocketIO with CORS options
+    socketio.init_app(app, cors_allowed_origins=app.config['CORS_ALLOWED_ORIGINS'])
+
     # Enable a 'startswith' test in our Jinja templates
     app.jinja_env.tests['startswith'] = lambda val, prefix: (
         isinstance(val, str) and val.startswith(prefix)
     )
-
-    # Basic config (you can improve this later)
-    app.config['SECRET_KEY'] = 'dev'  # change in prod!
-    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///debate_app.db'
-    app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 
     # Initialize extensions
     db.init_app(app)

--- a/config.py
+++ b/config.py
@@ -1,0 +1,8 @@
+import os
+
+class Config:
+    SECRET_KEY = os.getenv('SECRET_KEY', 'dev')
+    SQLALCHEMY_DATABASE_URI = os.getenv('SQLALCHEMY_DATABASE_URI', 'sqlite:///debate_app.db')
+    SQLALCHEMY_TRACK_MODIFICATIONS = os.getenv('SQLALCHEMY_TRACK_MODIFICATIONS', 'False').lower() in ('true', '1')
+    CORS_ALLOWED_ORIGINS = os.getenv('CORS_ALLOWED_ORIGINS', '*')
+    PORT = int(os.getenv('PORT', 5000))

--- a/run.py
+++ b/run.py
@@ -31,7 +31,5 @@ def create_initial_admin():
 
 if __name__ == '__main__':
     create_initial_admin()
-    
-    socketio.run(app, host="0.0.0.0", port=5000)
-    
-    app.run(debug=True)
+
+    socketio.run(app, host='0.0.0.0', port=app.config.get('PORT', 5000))


### PR DESCRIPTION
## Summary
- centralize configuration in new `config.py`
- load default configuration in `create_app`
- respect configured CORS and port when running
- document configuration options

## Testing
- `python -m py_compile config.py app/__init__.py run.py`

------
https://chatgpt.com/codex/tasks/task_e_684cbd5bbdbc8330be349fda11aea5de