### PR TITLE
Add inactive state checks for judging

### DIFF
--- a/app/debate/routes.py
+++ b/app/debate/routes.py
@@ -19,6 +19,9 @@ def get_chair_slot(user, debate_id):
 @login_required
 def judging(debate_id):
     debate = Debate.query.get_or_404(debate_id)
+    if not debate.active:
+        flash('This debate is inactive.', 'warning')
+        return redirect(url_for('main.debate_view', debate_id=debate_id))
     chair_slot = get_chair_slot(current_user, debate_id)
     if not chair_slot:
         flash('Only the chair judge can access this page.', 'danger')

--- a/app/templates/admin/dashboard.html
+++ b/app/templates/admin/dashboard.html
@@ -21,6 +21,9 @@
           <span class="badge {% if debate.voting_open %}bg-success{% else %}bg-danger{% endif %} ms-2">
             {% if debate.voting_open %}Voting Open{% else %}Voting Closed{% endif %}
           </span>
+          <span class="badge {% if debate.active %}bg-primary{% else %}bg-secondary{% endif %} ms-2">
+            {% if debate.active %}Active{% else %}Inactive{% endif %}
+          </span>
         </button>
       </h2>
       <div id="collapse{{ debate.id }}" class="accordion-collapse collapse" aria-labelledby="heading{{ debate.id }}" data-bs-parent="#debateAccordion">

--- a/app/templates/main/debate.html
+++ b/app/templates/main/debate.html
@@ -43,7 +43,11 @@
     </a>
     {% set my_slot = current_user.get_slot_for_debate(debate.id) %}
     {% if my_slot and my_slot.role == 'Judge-Chair' %}
-      <a href="{{ url_for('debate.judging', debate_id=debate.id) }}" class="btn btn-warning mt-3">Judging</a>
+      {% if debate.active %}
+        <a href="{{ url_for('debate.judging', debate_id=debate.id) }}" class="btn btn-warning mt-3">Judging</a>
+      {% else %}
+        <a class="btn btn-warning mt-3 disabled" aria-disabled="true">Judging</a>
+      {% endif %}
     {% endif %}
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- disable Judging button when debate is inactive
- show debate active/inactive badge on admin dashboard
- prevent direct access to judging page if debate is inactive

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d56d502f483309c654ef0d7ad1aba