### PR TITLE
Update user registration with first/last name

### DIFF
--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -221,7 +221,7 @@ def toggle_user_admin(user_id):
     user = User.query.get_or_404(user_id)
     user.is_admin = not user.is_admin
     db.session.commit()
-    flash(f"User '{user.username}' admin status changed.", "info")
+    flash(f"User '{user.first_name} {user.last_name}' admin status changed.", "info")
     return redirect(url_for('admin.manage_users'))
     
 @admin_bp.route('/admin/<int:debate_id>/assign', methods=['POST'])

--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -19,18 +19,23 @@ def register():
     if current_user.is_authenticated:
         return redirect(url_for('main.dashboard'))
     if request.method == 'POST':
-        username = request.form['username']
+        first_name = request.form['first_name']
+        last_name = request.form.get('last_name')
         email = request.form['email']
         password = request.form['password']
+        password2 = request.form['password2']
         # Basic validation (expand as needed)
-        if User.query.filter_by(username=username).first():
-            flash('Username already exists.')
+        if User.query.filter_by(first_name=first_name, last_name=last_name).first():
+            flash('User with that name already exists.')
             return redirect(url_for('auth.register'))
         if User.query.filter_by(email=email).first():
             flash('Email already registered.')
             return redirect(url_for('auth.register'))
+        if password != password2:
+            flash('Passwords do not match.')
+            return redirect(url_for('auth.register'))
         hashed_pw = generate_password_hash(password)
-        user = User(username=username, email=email, password=hashed_pw)
+        user = User(first_name=first_name, last_name=last_name, email=email, password=hashed_pw)
         db.session.add(user)
         db.session.commit()
         flash('Registration successful! Please log in.')

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -257,7 +257,7 @@ def debate_assignments_json(debate_id):
             'role': s.role,
             'room': s.room,
             'user_id': s.user_id,
-            'username': s.user.username
+            'name': f"{s.user.first_name} {s.user.last_name}"
         } for s in slots
     ]
 

--- a/app/models.py
+++ b/app/models.py
@@ -34,7 +34,8 @@ class JudgeSkillEnum(db.Enum):
 # User model: represents app users (debaters, admins, etc.)
 class User(UserMixin, db.Model):
     id = db.Column(db.Integer, primary_key=True)
-    username = db.Column(db.String(80), unique=True, nullable=False)
+    first_name = db.Column(db.String(80), nullable=False)
+    last_name = db.Column(db.String(80), nullable=True)
     email = db.Column(db.String(120), unique=True, nullable=False)
     password = db.Column(db.String(256), nullable=False)  # hashed password
     is_admin = db.Column(db.Boolean, default=False)
@@ -54,7 +55,7 @@ class User(UserMixin, db.Model):
         return SpeakerSlot.query.filter_by(debate_id=debate_id, user_id=self.id).first()
 
     def __repr__(self):
-        return f'<User {self.username}>'
+        return f'<User {self.first_name} {self.last_name}>'
 
 # Debate model: stores debate event details
 class Debate(db.Model):

--- a/app/profile/routes.py
+++ b/app/profile/routes.py
@@ -7,11 +7,14 @@ from . import profile_bp
 @login_required
 def view():
     if request.method == 'POST':
-        # Allow editing username and email only
-        username = request.form.get('username')
+        # Allow editing name and email only
+        first_name = request.form.get('first_name')
+        last_name = request.form.get('last_name')
         email = request.form.get('email')
-        if username and username != current_user.username:
-            current_user.username = username
+        if first_name and first_name != current_user.first_name:
+            current_user.first_name = first_name
+        if last_name is not None and last_name != current_user.last_name:
+            current_user.last_name = last_name
         if email and email != current_user.email:
             current_user.email = email
         db.session.commit()

--- a/app/static/js/dashboard.js
+++ b/app/static/js/dashboard.js
@@ -57,7 +57,7 @@ function createBadge(slot) {
   span.classList.add('role-badge');
   if (slot.user_id == window.currentUserId) span.classList.add('me');
   span.setAttribute('role', 'listitem');
-  span.setAttribute('aria-label', `${slot.role} – ${slot.username}`);
+  span.setAttribute('aria-label', `${slot.role} – ${slot.name}`);
 
   const icon = document.createElement('i');
   icon.classList.add('bi');
@@ -69,7 +69,7 @@ function createBadge(slot) {
 
   span.appendChild(document.createTextNode(` ${slot.role}`));
   span.appendChild(document.createElement('br'));
-  span.appendChild(document.createTextNode(slot.username));
+  span.appendChild(document.createTextNode(slot.name));
   if (slot.user_id == window.currentUserId) {
     const em = document.createElement('em');
     em.textContent = ' (You)';

--- a/app/templates/admin/dynamic_plan.html
+++ b/app/templates/admin/dynamic_plan.html
@@ -6,8 +6,8 @@
   <h4>Participants Grouped by Skill</h4>
   <ul>
   {% for skill, users in groups.items() %}
-    <li><strong>{{ skill }} ({{ users|length }})</strong>: 
-        {% for u in users %}{{ u.username }}{% if not loop.last %}, {% endif %}{% endfor %}
+    <li><strong>{{ skill }} ({{ users|length }})</strong>:
+        {% for u in users %}{{ u.first_name }} {{ u.last_name }}{% if not loop.last %}, {% endif %}{% endfor %}
     </li>
   {% endfor %}
   </ul>

--- a/app/templates/admin/users.html
+++ b/app/templates/admin/users.html
@@ -6,7 +6,7 @@
   <thead>
     <tr>
       <th>ID</th>
-      <th>Username</th>
+      <th>Name</th>
       <th>Email</th>
       <th>Admin</th>
       <th>Join Time (Survey)</th>
@@ -21,7 +21,7 @@
     {% for user in users %}
     <tr>
       <td>{{ user.id }}</td>
-      <td>{{ user.username }}</td>
+      <td>{{ user.first_name }} {{ user.last_name }}</td>
       <td>{{ user.email }}</td>
       <td>{% if user.is_admin %}<span class="badge bg-success">Yes</span>{% else %}No{% endif %}</td>
       <td>{{ user.date_joined_choice or "—" }}</td>

--- a/app/templates/auth/register.html
+++ b/app/templates/auth/register.html
@@ -9,8 +9,12 @@
 
       <form method="POST" action="{{ url_for('auth.register') }}">
         <div class="mb-3">
-          <label for="username" class="form-label">Username</label>
-          <input type="text" class="form-control" id="username" name="username" placeholder="Choose a username" required autofocus>
+          <label for="first_name" class="form-label">First Name</label>
+          <input type="text" class="form-control" id="first_name" name="first_name" placeholder="Enter your first name" required autofocus>
+        </div>
+        <div class="mb-3">
+          <label for="last_name" class="form-label">Last Name</label>
+          <input type="text" class="form-control" id="last_name" name="last_name" placeholder="Enter your last name">
         </div>
         <div class="mb-3">
           <label for="email" class="form-label">Email address</label>
@@ -19,6 +23,10 @@
         <div class="mb-3">
           <label for="password" class="form-label">Password</label>
           <input type="password" class="form-control" id="password" name="password" placeholder="Choose a password" required>
+        </div>
+        <div class="mb-3">
+          <label for="password2" class="form-label">Repeat Password</label>
+          <input type="password" class="form-control" id="password2" name="password2" placeholder="Repeat your password" required>
         </div>
         <button type="submit" class="btn btn-success w-100">Register</button>
       </form>

--- a/app/templates/debate/judging_opd.html
+++ b/app/templates/debate/judging_opd.html
@@ -8,7 +8,7 @@
       <tr>
         <th>Speaker</th>
         {% for j in judges %}
-          <th>{{ j.user.username }}</th>
+          <th>{{ j.user.first_name }} {{ j.user.last_name }}</th>
         {% endfor %}
         <th>Average</th>
       </tr>
@@ -16,7 +16,7 @@
     <tbody>
       {% for sp in speakers %}
       <tr data-role="{{ sp.role }}" data-sid="{{ sp.id }}">
-        <td>{{ sp.user.username }} <small class="text-muted">({{ sp.role }})</small></td>
+        <td>{{ sp.user.first_name }} {{ sp.user.last_name }} <small class="text-muted">({{ sp.role }})</small></td>
         {% for j in judges %}
           <td><input type="number" min="0" max="100" step="1" name="score_{{ sp.id }}_{{ j.id }}" class="form-control score-input" value="{{ scores.get((sp.user_id, j.user_id), '') }}"></td>
         {% endfor %}

--- a/app/templates/main/_role_badge.html
+++ b/app/templates/main/_role_badge.html
@@ -1,7 +1,7 @@
 {# Re-usable badge component #}
 <span class="role-badge {{ 'me' if user.id == slot.user_id else '' }}"
       role="listitem"
-      aria-label="{{ slot.role }} – {{ slot.user.username }}">
+      aria-label="{{ slot.role }} – {{ slot.user.first_name }} {{ slot.user.last_name }}">
   {% if slot.role.startswith('Judge') %}
     <i class="bi bi-gavel"></i>
   {% elif slot.role.startswith('Free') %}
@@ -12,5 +12,5 @@
     <i class="bi bi-patch-question"></i>
   {% endif %}
   {{ slot.role }}<br>
-  {{ slot.user.username }}{% if user.id == slot.user_id %} <em>(You)</em>{% endif %}
+  {{ slot.user.first_name }} {{ slot.user.last_name }}{% if user.id == slot.user_id %} <em>(You)</em>{% endif %}
 </span>

--- a/app/templates/main/dashboard.html
+++ b/app/templates/main/dashboard.html
@@ -21,7 +21,7 @@
 
   <!-- Welcome Banner -->
   <div class="mb-4 text-center">
-    <h2>Welcome, {{ current_user.username }}!</h2>
+    <h2>Welcome, {{ current_user.first_name }} {{ current_user.last_name }}!</h2>
   </div>
 
   <!-- Current Debate Card -->

--- a/app/templates/main/debate_assignments.html
+++ b/app/templates/main/debate_assignments.html
@@ -24,7 +24,7 @@
           {% for slot in slots %}
             <tr>
               <td>{{ slot.role }}</td>
-              <td>{{ user_map[slot.user_id].username }}</td>
+              <td>{{ user_map[slot.user_id].first_name }} {{ user_map[slot.user_id].last_name }}</td>
               <td>{{ user_map[slot.user_id].debate_skill }}</td>
               <td>{{ user_map[slot.user_id].judge_skill }}</td>
             </tr>

--- a/app/templates/profile/view.html
+++ b/app/templates/profile/view.html
@@ -4,8 +4,12 @@
 <h2>Profile</h2>
 <form method="post" class="mb-3">
   <div class="mb-3">
-    <label class="form-label">Username</label>
-    <input name="username" class="form-control" value="{{ current_user.username }}">
+    <label class="form-label">First Name</label>
+    <input name="first_name" class="form-control" value="{{ current_user.first_name }}">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Last Name</label>
+    <input name="last_name" class="form-control" value="{{ current_user.last_name }}">
   </div>
   <div class="mb-3">
     <label class="form-label">Email</label>

--- a/migrations/versions/1a2b3c4d5e6f_add_first_last_name.py
+++ b/migrations/versions/1a2b3c4d5e6f_add_first_last_name.py
@@ -1,0 +1,41 @@
+"""add first and last name fields
+
+Revision ID: 1a2b3c4d5e6f
+Revises: 0d2e6c501f2d
+Create Date: 2025-05-28 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '1a2b3c4d5e6f'
+down_revision = '0d2e6c501f2d'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('user', schema=None) as batch_op:
+        batch_op.alter_column(
+            'username',
+            new_column_name='first_name',
+            existing_type=sa.String(length=80),
+            existing_nullable=False,
+            existing_server_default=None,
+            unique=False
+        )
+        batch_op.add_column(sa.Column('last_name', sa.String(length=80), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table('user', schema=None) as batch_op:
+        batch_op.drop_column('last_name')
+        batch_op.alter_column(
+            'first_name',
+            new_column_name='username',
+            existing_type=sa.String(length=80),
+            existing_nullable=False,
+            existing_server_default=None,
+            unique=True
+        )

--- a/run.py
+++ b/run.py
@@ -10,12 +10,14 @@ def create_initial_admin():
         db.create_all()
         if not User.query.filter_by(is_admin=True).first():
             # Change credentials as needed!
-            username = 'admin'
+            first_name = 'Admin'
+            last_name = 'User'
             email = 'admin@example.com'
             password = 'admin123'
             if not User.query.filter_by(email=email).first():
                 admin = User(
-                    username=username,
+                    first_name=first_name,
+                    last_name=last_name,
                     email=email,
                     password=generate_password_hash(password),
                     is_admin=True


### PR DESCRIPTION
## Summary
- introduce `first_name` and `last_name` fields on `User`
- add Alembic migration to rename `username` and add new column
- update registration process and profile editing for new fields
- show user's full name in templates and admin messages
- adjust JS and API responses for full name display

## Testing
- `python3 -m compileall -q app run.py start.py`

------
https://chatgpt.com/codex/tasks/task_e_684d5b62e35083309081e5c3f79f840b