### PR TITLE
Add elo tracking and result models

### DIFF
--- a/app/debate/routes.py
+++ b/app/debate/routes.py
@@ -1,7 +1,7 @@
 from flask import render_template, request, redirect, url_for, flash
 from flask_login import login_required, current_user
 from app.extensions import db
-from app.models import Debate, SpeakerSlot, Score, BpRank
+from app.models import Debate, SpeakerSlot, Score, BpRank, OpdResult, EloLog, User
 
 from . import debate_bp
 
@@ -85,3 +85,62 @@ def judging(debate_id):
         ).all()
     }
     return render_template('debate/judging_opd.html', debate=debate, judges=judges, speakers=speakers, scores=scores)
+
+
+@debate_bp.route('/debate/<int:debate_id>/finalize', methods=['POST'])
+@login_required
+def finalize(debate_id):
+    """Finalize a debate and record results/Elo."""
+    debate = Debate.query.get_or_404(debate_id)
+    if not debate.active:
+        flash('This debate is inactive.', 'warning')
+        return redirect(url_for('main.debate_view', debate_id=debate_id))
+    chair_slot = get_chair_slot(current_user, debate_id)
+    if not chair_slot:
+        flash('Only the chair judge can finalize this debate.', 'danger')
+        return redirect(url_for('main.debate_view', debate_id=debate_id))
+
+    judge_ids = [s.user_id for s in SpeakerSlot.query.filter(
+        SpeakerSlot.debate_id == debate_id,
+        SpeakerSlot.room == chair_slot.room,
+        SpeakerSlot.role.startswith('Judge')
+    ).all()]
+
+    speaker_slots = SpeakerSlot.query.filter(
+        SpeakerSlot.debate_id == debate_id,
+        SpeakerSlot.room == chair_slot.room,
+        ~SpeakerSlot.role.startswith('Judge')
+    ).all()
+
+    OpdResult.query.filter_by(debate_id=debate_id).delete()
+    EloLog.query.filter_by(debate_id=debate_id).delete()
+
+    if debate.style == 'OPD':
+        for sp in speaker_slots:
+            avg = db.session.query(db.func.avg(Score.value)).filter(
+                Score.debate_id == debate_id,
+                Score.speaker_id == sp.user_id,
+                Score.judge_id.in_(judge_ids)
+            ).scalar() or 0
+            db.session.add(OpdResult(debate_id=debate_id, user_id=sp.user_id, points=avg))
+            old = sp.user.elo_rating or 1000
+            new = old + (avg - 50) / 10
+            sp.user.elo_rating = new
+            db.session.add(EloLog(debate_id=debate_id, user_id=sp.user_id, old_elo=old, new_elo=new, change=new-old))
+    else:  # BP
+        ranks = {r.team: r.rank for r in BpRank.query.filter_by(debate_id=debate_id).all()}
+        team_points = {1: 3, 2: 2, 3: 1, 4: 0}
+        for sp in speaker_slots:
+            team = sp.role.split('-')[0]
+            rank = ranks.get(team)
+            pts = team_points.get(rank, 0)
+            db.session.add(OpdResult(debate_id=debate_id, user_id=sp.user_id, points=pts))
+            old = sp.user.elo_rating or 1000
+            new = old + pts - 1.5
+            sp.user.elo_rating = new
+            db.session.add(EloLog(debate_id=debate_id, user_id=sp.user_id, old_elo=old, new_elo=new, change=new-old))
+
+    debate.active = False
+    db.session.commit()
+    flash('Debate finalized.', 'success')
+    return redirect(url_for('main.debate_view', debate_id=debate_id))

--- a/app/templates/profile/view.html
+++ b/app/templates/profile/view.html
@@ -21,4 +21,14 @@
 <p><strong>Debate Skill:</strong> {{ current_user.debate_skill or '—' }}</p>
 <p><strong>Judge Skill:</strong> {{ current_user.judge_skill or '—' }}</p>
 <p><strong>Debates Participated:</strong> {{ current_user.debate_count or 0 }}</p>
+<p><strong>Elo Rating:</strong> {{ current_user.elo_rating }}</p>
+{% set recent = current_user.recent_opd_results() %}
+{% if recent %}
+<h5 class="mt-4">Recent Results</h5>
+<ul>
+  {% for r in recent %}
+    <li>Debate {{ r.debate_id }}: {{ '%.1f'|format(r.points) }} pts</li>
+  {% endfor %}
+</ul>
+{% endif %}
 {% endblock %}

--- a/migrations/versions/36e28fa7db45_add_elo_and_results.py
+++ b/migrations/versions/36e28fa7db45_add_elo_and_results.py
@@ -1,0 +1,51 @@
+"""add elo rating and result tables
+
+Revision ID: 36e28fa7db45
+Revises: 0d2e6c501f2d
+Create Date: 2025-05-30 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = '36e28fa7db45'
+down_revision = '0d2e6c501f2d'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('user', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('elo_rating', sa.Integer(), server_default='1000', nullable=True))
+    op.create_table(
+        'opd_result',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('debate_id', sa.Integer(), nullable=False),
+        sa.Column('user_id', sa.Integer(), nullable=False),
+        sa.Column('points', sa.Float()),
+        sa.ForeignKeyConstraint(['debate_id'], ['debate.id']),
+        sa.ForeignKeyConstraint(['user_id'], ['user.id']),
+        sa.UniqueConstraint('debate_id', 'user_id', name='opd_result_unique')
+    )
+    op.create_table(
+        'elo_log',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('debate_id', sa.Integer(), nullable=False),
+        sa.Column('user_id', sa.Integer(), nullable=False),
+        sa.Column('old_elo', sa.Float(), nullable=False),
+        sa.Column('new_elo', sa.Float(), nullable=False),
+        sa.Column('change', sa.Float(), nullable=False),
+        sa.ForeignKeyConstraint(['debate_id'], ['debate.id']),
+        sa.ForeignKeyConstraint(['user_id'], ['user.id']),
+        sa.UniqueConstraint('debate_id', 'user_id', name='elo_log_unique')
+    )
+    op.execute("UPDATE user SET elo_rating = 1000")
+    with op.batch_alter_table('user', schema=None) as batch_op:
+        batch_op.alter_column('elo_rating', server_default=None)
+
+
+def downgrade():
+    op.drop_table('elo_log')
+    op.drop_table('opd_result')
+    with op.batch_alter_table('user', schema=None) as batch_op:
+        batch_op.drop_column('elo_rating')


### PR DESCRIPTION
## Summary
- add `elo_rating` to `User`
- track OPD debate results and elo logs
- finalize debates to record results and elo changes
- show Elo rating and recent results on profile
- database migration for new tables and column

## Testing
- `python -m py_compile app/models.py app/debate/routes.py migrations/versions/36e28fa7db45_add_elo_and_results.py`

------
https://chatgpt.com/codex/tasks/task_e_684d646cefb08330ade320cd83c940c5