### PR TITLE
Add OPD skill tracking and profile improvements

### DIFF
--- a/app/debate/routes.py
+++ b/app/debate/routes.py
@@ -142,5 +142,13 @@ def finalize(debate_id):
 
     debate.active = False
     db.session.commit()
+
+    if debate.style == 'OPD':
+        user_ids = {sp.user_id for sp in speaker_slots}
+        for uid in user_ids:
+            user = User.query.get(uid)
+            if user:
+                user.update_opd_skill()
+        db.session.commit()
     flash('Debate finalized.', 'success')
     return redirect(url_for('main.debate_view', debate_id=debate_id))

--- a/app/profile/routes.py
+++ b/app/profile/routes.py
@@ -1,6 +1,7 @@
 from flask import render_template, request, redirect, url_for, flash
 from flask_login import login_required, current_user
 from app.extensions import db
+from app.models import OpdResult, Debate, EloLog, SpeakerSlot, BpRank
 from . import profile_bp
 
 @profile_bp.route('/profile', methods=['GET', 'POST'])
@@ -20,4 +21,25 @@ def view():
         db.session.commit()
         flash('Profile updated.', 'success')
         return redirect(url_for('profile.view'))
-    return render_template('profile/view.html')
+
+    opd_result_count = current_user.opd_result_count()
+
+    results = OpdResult.query.filter_by(user_id=current_user.id).order_by(
+        OpdResult.id.desc()
+    ).limit(20).all()
+    recent_debates = []
+    for res in results:
+        debate = Debate.query.get(res.debate_id)
+        log = EloLog.query.filter_by(debate_id=res.debate_id, user_id=current_user.id).first()
+        change = log.change if log else 0
+        rank = None
+        if debate.style == 'BP':
+            slot = SpeakerSlot.query.filter_by(debate_id=res.debate_id, user_id=current_user.id).first()
+            team = slot.role.split('-')[0] if slot else None
+            if team:
+                bp = BpRank.query.filter_by(debate_id=res.debate_id, team=team).first()
+                if bp:
+                    rank = bp.rank
+        recent_debates.append({'debate': debate, 'points': res.points, 'elo_change': change, 'rank': rank})
+
+    return render_template('profile/view.html', opd_result_count=opd_result_count, recent_debates=recent_debates)

--- a/app/templates/profile/view.html
+++ b/app/templates/profile/view.html
@@ -21,14 +21,53 @@
 <p><strong>Debate Skill:</strong> {{ current_user.debate_skill or '—' }}</p>
 <p><strong>Judge Skill:</strong> {{ current_user.judge_skill or '—' }}</p>
 <p><strong>Debates Participated:</strong> {{ current_user.debate_count or 0 }}</p>
-<p><strong>Elo Rating:</strong> {{ current_user.elo_rating }}</p>
-{% set recent = current_user.recent_opd_results() %}
-{% if recent %}
-<h5 class="mt-4">Recent Results</h5>
-<ul>
-  {% for r in recent %}
-    <li>Debate {{ r.debate_id }}: {{ '%.1f'|format(r.points) }} pts</li>
+<p><strong>BP Ranking:</strong> {{ current_user.elo_rating }}</p>
+<p><strong>OPD Skill:</strong>
+  {% if opd_result_count == 0 %}
+    None
+  {% elif opd_result_count < 5 %}
+    {{ 5 - opd_result_count }} debates until ranked
+  {% else %}
+    {{ '%.1f'|format(current_user.opd_skill) }}
+  {% endif %}
+</p>
+{% if recent_debates %}
+<h5 class="mt-4">Recent Debates</h5>
+<ul id="debateList" class="list-group mb-2">
+  {% for item in recent_debates %}
+    <li class="list-group-item debate-item" style="display:none;">
+      <strong>{{ item.debate.title }}</strong> ({{ item.debate.style }}) -
+      {% if item.debate.style == 'BP' %}
+        Place {{ item.rank or '?' }}, Elo {{ '%+.1f'|format(item.elo_change or 0) }}
+      {% else %}
+        {{ '%.1f pts'|format(item.points) }}
+      {% endif %}
+    </li>
   {% endfor %}
 </ul>
+<div class="d-flex justify-content-between mb-3">
+  <button id="prevPage" class="btn btn-secondary btn-sm">Prev</button>
+  <button id="nextPage" class="btn btn-secondary btn-sm">Next</button>
+</div>
 {% endif %}
+{% endblock %}
+
+{% block extra_js %}
+<script>
+  const items = document.querySelectorAll('#debateList .debate-item');
+  let page = 0;
+  const pageSize = 5;
+  function showPage() {
+    items.forEach((el, i) => {
+      el.style.display = (i >= page * pageSize && i < (page + 1) * pageSize) ? '' : 'none';
+    });
+  }
+  document.getElementById('prevPage')?.addEventListener('click', () => {
+    if (page > 0) { page--; showPage(); }
+  });
+  document.getElementById('nextPage')?.addEventListener('click', () => {
+    if ((page + 1) * pageSize < items.length) { page++; showPage(); }
+  });
+  showPage();
+</script>
 {% endblock %}

--- a/migrations/versions/7c29a14798c9_add_opd_skill_to_user.py
+++ b/migrations/versions/7c29a14798c9_add_opd_skill_to_user.py
@@ -1,0 +1,19 @@
+"""add opd_skill to user"""
+
+revision = '7c29a14798c9'
+down_revision = '36e28fa7db45'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    with op.batch_alter_table('user', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('opd_skill', sa.Float(), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table('user', schema=None) as batch_op:
+        batch_op.drop_column('opd_skill')


### PR DESCRIPTION
## Summary
- track OPD skill average in `User`
- update debate finalization to refresh OPD skill
- show BP ranking and OPD skill on profile
- list recent debates with paging
- add migration for `opd_skill`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684d684447d88330a517591d54804c33