### PR TITLE
Allow dynamic debates to contribute to OPD skill

### DIFF
--- a/app/debate/routes.py
+++ b/app/debate/routes.py
@@ -143,7 +143,7 @@ def finalize(debate_id):
     debate.active = False
     db.session.commit()
 
-    if debate.style == 'OPD':
+    if debate.style in ('OPD', 'Dynamic'):
         user_ids = {sp.user_id for sp in speaker_slots}
         for uid in user_ids:
             user = User.query.get(uid)

--- a/app/models.py
+++ b/app/models.py
@@ -70,7 +70,10 @@ class User(UserMixin, db.Model):
     def update_opd_skill(self, n=5):
         results = (
             OpdResult.query.join(Debate, OpdResult.debate_id == Debate.id)
-            .filter(OpdResult.user_id == self.id, Debate.style == 'OPD')
+            .filter(
+                OpdResult.user_id == self.id,
+                Debate.style.in_(("OPD", "Dynamic"))
+            )
             .order_by(OpdResult.id.desc())
             .limit(n)
             .all()
@@ -84,7 +87,7 @@ class User(UserMixin, db.Model):
     def opd_result_count(self):
         return OpdResult.query.join(Debate, OpdResult.debate_id == Debate.id).filter(
             OpdResult.user_id == self.id,
-            Debate.style == 'OPD'
+            Debate.style.in_(("OPD", "Dynamic"))
         ).count()
 
     def __repr__(self):


### PR DESCRIPTION
## Summary
- expand skill queries to count Dynamic results as OPD
- update debate finalization logic to refresh OPD skill for Dynamic debates

## Testing
- `python -m py_compile app/models.py app/debate/routes.py`

------
https://chatgpt.com/codex/tasks/task_e_684d6ef9c6ec83308543cc8172f127cd