### PR TITLE
Add finalize button in judging templates

### DIFF
--- a/app/templates/debate/judging_bp.html
+++ b/app/templates/debate/judging_bp.html
@@ -17,6 +17,9 @@
   <p id="rank-warning" class="text-danger d-none">Each rank must be used once.</p>
   <button id="save-btn" type="submit" class="btn btn-primary">Save</button>
 </form>
+<form method="post" action="{{ url_for('debate.finalize', debate_id=debate.id) }}" onsubmit="return confirm('Finalize this debate?');">
+  <button type="submit" class="btn btn-danger mt-3">Finalize Debate</button>
+</form>
 {% endblock %}
 {% block extra_js %}
 <script>

--- a/app/templates/debate/judging_opd.html
+++ b/app/templates/debate/judging_opd.html
@@ -29,6 +29,9 @@
   <p><strong>Opposition:</strong> <span id="opp-total">0</span></p>
   <button type="submit" class="btn btn-primary">Save</button>
 </form>
+<form method="post" action="{{ url_for('debate.finalize', debate_id=debate.id) }}" onsubmit="return confirm('Finalize this debate?');">
+  <button type="submit" class="btn btn-danger mt-3">Finalize Debate</button>
+</form>
 {% endblock %}
 {% block extra_js %}
 <script>


### PR DESCRIPTION
## Summary
- allow chair judges to finalize debates from judging screens

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- manual finalize flow to ensure `OpdResult` records are created

------
https://chatgpt.com/codex/tasks/task_e_684d75b1d1b883308f0e46717fe1dbb3