### PR TITLE
Restore speaker graphic visibility

### DIFF
--- a/app/static/js/dashboard.js
+++ b/app/static/js/dashboard.js
@@ -195,6 +195,7 @@ function populateGraphic() {
       cont.appendChild(diagramCont);
 
       renderRoomGraphic(diagramCont, data, currentRoom);
+      cont.style.display = 'block';
     });
 }
 


### PR DESCRIPTION
## Summary
- show the debate graphic container when rendering speaker assignments

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684d7739c0fc83308968495f632fc6a2