### PR TITLE
Drop first_name uniqueness

### DIFF
--- a/migrations/versions/363076fe0622_remove_first_name_unique.py
+++ b/migrations/versions/363076fe0622_remove_first_name_unique.py
@@ -1,0 +1,19 @@
+"""remove first_name unique"""
+
+revision = '363076fe0622'
+down_revision = '1c4cfe455b23'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    with op.batch_alter_table('user') as batch_op:
+        batch_op.drop_constraint('user_username_key', type_='unique')
+
+
+def downgrade():
+    with op.batch_alter_table('user') as batch_op:
+        batch_op.create_unique_constraint('user_username_key', ['first_name'])


### PR DESCRIPTION
## Summary
- add migration to remove the `first_name` unique constraint

## Testing
- `flask db downgrade 1c4cfe455b23 && flask db upgrade`
- `sqlite3 instance/debate_app.db "PRAGMA index_list('user');"`
- `sqlite3 instance/debate_app.db ".schema user"`


------
https://chatgpt.com/codex/tasks/task_e_684da40ad7808330811541d254151f1d