### PR TITLE
UI overhaul for debate dashboard

### DIFF
--- a/app/static/css/dashboard.css
+++ b/app/static/css/dashboard.css
@@ -18,3 +18,14 @@
 #graphicContainer {
   width: 100%;
 }
+
+.vote-progress-fixed {
+  position: fixed;
+  top: var(--spacing-unit);
+  right: var(--spacing-unit);
+  width: 200px;
+  z-index: 1030;
+}
+.vote-progress-fixed .progress-bar {
+  transition: width 0.3s ease;
+}

--- a/app/static/css/graphic.css
+++ b/app/static/css/graphic.css
@@ -1,21 +1,24 @@
 /* typography & base */
 .diagram-opd,
 .diagram-bp {display:flex;flex-wrap:wrap;flex-direction:column;gap:1rem;margin-bottom:2rem}
-.bench      {flex:1 1 100%;padding:1rem;border-radius:.5rem}
-.free-area  {flex:1 1 0;text-align:center;min-width:150px;background:#f8f9fa;border-radius:.5rem;padding:.75rem;margin-bottom:1rem}
-.gov-bench  {background:#e7f3ff}
-.opp-bench  {background:#ffe7e7}
+.bench      {flex:1 1 100%;padding:1rem;border-radius:.5rem;position:relative;transform:perspective(600px) rotateX(10deg);box-shadow:0 2px 4px rgba(0,0,0,0.1)}
+.free-area  {flex:1 1 0;text-align:center;min-width:150px;background:var(--free-color);border-radius:.5rem;padding:.75rem;margin-bottom:1rem}
+.gov-bench  {background:var(--gov-color)}
+.opp-bench  {background:var(--opp-color)}
 .bench-title{font-weight:600;margin-bottom:.5rem}
 
 .role-badge{display:inline-block;padding:.35rem .6rem;font-size:.9rem;
   line-height:1.2;border-radius:1rem;background:#dee2e6}
+.role-badge.gov{background:var(--gov-color)}
+.role-badge.opp{background:var(--opp-color)}
+.role-badge.judge{background:var(--judge-color)}
+.role-badge.free{background:var(--free-color)}
 .role-badge.me{box-shadow:0 0 0 2px var(--bs-success)}
 .bp-team-card{flex:1 1 calc(25% - .75rem);background:#f8f9fa;padding:.75rem;
   border-radius:.5rem;text-align:center}
 .bp-title{font-weight:600;margin-bottom:.25rem}
 .placeholder{opacity:.5;font-size:.85rem}
 .judges-row{display:flex;gap:.5rem;flex-wrap:wrap;overflow-x:auto}
-.judges-row .role-badge{background:#cfe2ff}
 
 @media (min-width:768px){
   .bench{flex:1 1 calc(50% - .75rem);min-width:180px}

--- a/app/static/css/styles.css
+++ b/app/static/css/styles.css
@@ -1,0 +1,26 @@
+:root {
+  --gov-color: #e6f2ff;
+  --opp-color: #ffe6e6;
+  --judge-color: #fff4d6;
+  --free-color: #f8f9fa;
+  --spacing-unit: 8px;
+}
+body {
+  font-family: 'Inter', sans-serif;
+  line-height: 1.5;
+}
+
+.vote-progress-fixed {
+  position: fixed;
+  top: var(--spacing-unit);
+  right: var(--spacing-unit);
+  width: 200px;
+  z-index: 1030;
+}
+.vote-progress-fixed .progress-bar {
+  transition: width 0.3s ease;
+}
+.role-badge.gov { background: var(--gov-color); }
+.role-badge.opp { background: var(--opp-color); }
+.role-badge.judge { background: var(--judge-color); }
+.role-badge.free { background: var(--free-color); }

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -6,7 +6,11 @@
     <title>{% block title %}Debate App{% endblock %}</title>
 
     <!-- Global CSS -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/styles.css') }}">
 
     <!-- Page-specific CSS -->
     {% block extra_head %}{% endblock %}
@@ -19,18 +23,25 @@
       <span class="navbar-toggler-icon"></span>
     </button>
     <div class="collapse navbar-collapse" id="navbarNav">
-      <ul class="navbar-nav ms-auto">
+      <ul class="navbar-nav ms-auto align-items-center">
         <li class="nav-item">
-          <a class="nav-link" href="{{ url_for('profile.view') }}">Profile</a>
+          <button id="themeToggle" class="btn btn-outline-secondary btn-sm me-2" type="button">
+            <i class="bi bi-moon-fill"></i>
+          </button>
         </li>
-        {% if current_user.is_authenticated and current_user.is_admin %}
-        <li class="nav-item">
-          <a class="nav-link" href="{{ url_for('admin.admin_dashboard') }}">Admin</a>
-        </li>
-        {% endif %}
         {% if current_user.is_authenticated %}
-        <li class="nav-item">
-          <a class="nav-link" href="{{ url_for('auth.logout') }}">Logout</a>
+        <li class="nav-item dropdown">
+          <a class="nav-link dropdown-toggle" href="#" id="userMenu" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+            {{ current_user.first_name }}
+          </a>
+          <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="userMenu">
+            <li><a class="dropdown-item" href="{{ url_for('profile.view') }}">Profile</a></li>
+            {% if current_user.is_admin %}
+            <li><a class="dropdown-item" href="{{ url_for('admin.admin_dashboard') }}">Admin</a></li>
+            {% endif %}
+            <li><hr class="dropdown-divider"></li>
+            <li><a class="dropdown-item" href="{{ url_for('auth.logout') }}">Logout</a></li>
+          </ul>
         </li>
         {% endif %}
       </ul>
@@ -56,6 +67,16 @@
 <!-- Global JS -->
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 <script src="https://cdn.socket.io/4.7.5/socket.io.min.js"></script>
+<script>
+  const storedTheme = localStorage.getItem('theme') || 'light';
+  document.documentElement.setAttribute('data-bs-theme', storedTheme);
+  document.getElementById('themeToggle')?.addEventListener('click', () => {
+    const current = document.documentElement.getAttribute('data-bs-theme');
+    const next = current === 'dark' ? 'light' : 'dark';
+    document.documentElement.setAttribute('data-bs-theme', next);
+    localStorage.setItem('theme', next);
+  });
+</script>
 
 <!-- Page-specific JS -->
 {% block extra_js %}{% endblock %}

--- a/app/templates/main/_role_badge.html
+++ b/app/templates/main/_role_badge.html
@@ -1,7 +1,15 @@
 {# Re-usable badge component #}
-<span class="role-badge {{ 'me' if user.id == slot.user_id else '' }}"
+{% set cls = (
+  'judge' if slot.role.startswith('Judge') else
+  'free' if slot.role.startswith('Free') else
+  'gov' if slot.role in ('Gov','OG','CG') else
+  'opp'
+) %}
+<span class="role-badge {{ cls }} {{ 'me' if user.id == slot.user_id else '' }}"
       role="listitem"
-      aria-label="{{ slot.role }} – {{ slot.user.first_name }} {{ slot.user.last_name }}">
+      aria-label="{{ slot.role }} – {{ slot.user.first_name }} {{ slot.user.last_name }}"
+      data-bs-toggle="tooltip"
+      title="{{ slot.user.first_name }} {{ slot.user.last_name }} ({{ slot.role }})">
   {% if slot.role.startswith('Judge') %}
     <i class="bi bi-gavel"></i>
   {% elif slot.role.startswith('Free') %}

--- a/app/templates/main/dashboard.html
+++ b/app/templates/main/dashboard.html
@@ -19,6 +19,12 @@
 
 <div class="container my-4">
 
+  <div id="fixedProgress" class="vote-progress-fixed" style="display:{% if current_debate %}block{% else %}none{% endif %};">
+    <div class="progress" style="height:1rem;">
+      <div class="progress-bar bg-success" style="width: {{ vote_percent or 0 }}%;" aria-valuenow="{{ vote_percent or 0 }}" aria-valuemin="0" aria-valuemax="100"></div>
+    </div>
+  </div>
+
   <!-- Welcome Banner -->
   <div class="mb-4 text-center">
     <h2>Welcome, {{ current_user.first_name }} {{ current_user.last_name }}!</h2>

--- a/app/templates/main/graphic.html
+++ b/app/templates/main/graphic.html
@@ -115,26 +115,12 @@
     Back to debate
   </a>
 
-  <nav class="position-fixed bottom-0 end-0 p-3">
-    <button id="themeToggle" class="btn btn-outline-secondary btn-sm">
-      <i class="bi bi-moon-fill"></i>
-    </button>
-  </nav>
 </div>
 {% endblock %}
 
 {% block extra_js %}
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 <script>
-  // Dark-mode toggle
-  const btn = document.getElementById('themeToggle');
-  const stored = localStorage.getItem('theme') || 'light';
-  document.documentElement.setAttribute('data-bs-theme', stored);
-  btn.addEventListener('click', () => {
-    const current = document.documentElement.getAttribute('data-bs-theme');
-    const next = current === 'dark' ? 'light' : 'dark';
-    document.documentElement.setAttribute('data-bs-theme', next);
-    localStorage.setItem('theme', next);
-  });
+  document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(el => new bootstrap.Tooltip(el));
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add Inter font and global style variables
- implement dropdown user menu with dark mode toggle in base template
- add fixed vote progress bar on dashboard
- color-code role badges and enable tooltips
- update OPD layout styling with perspective effect

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684db2935f5c8330ade48faf43e1fa46