### PR TITLE
Add BP elo rating via openskill

### DIFF
--- a/app/logic/elo.py
+++ b/app/logic/elo.py
@@ -1,0 +1,38 @@
+from typing import List, Dict, Tuple
+from openskill.models import PlackettLuce, PlackettLuceRating
+from app.models import SpeakerSlot
+
+DEFAULT_MU = 1000.0
+DEFAULT_SIGMA = DEFAULT_MU / 3.0
+
+pl_model = PlackettLuce(mu=DEFAULT_MU, sigma=DEFAULT_SIGMA)
+
+
+def compute_bp_elo(slots: List[SpeakerSlot], ranks: Dict[str, int]) -> List[Tuple[SpeakerSlot, float, float]]:
+    """Return list of (slot, old_elo, new_elo) after rating update."""
+    teams: Dict[str, List[SpeakerSlot]] = {}
+    for slot in slots:
+        team = slot.role.split('-')[0]
+        teams.setdefault(team, []).append(slot)
+
+    # Ensure teams order stable for rating call
+    ordered_teams = sorted(teams.keys(), key=lambda t: ranks.get(t, 5))
+    team_ratings = []
+    for team in ordered_teams:
+        rating_team = []
+        for slot in teams[team]:
+            mu = float(slot.user.elo_rating or DEFAULT_MU)
+            rating_team.append(PlackettLuceRating(mu=mu, sigma=DEFAULT_SIGMA))
+        team_ratings.append(rating_team)
+
+    ranks_list = [ranks.get(team, 4) for team in ordered_teams]
+    new_ratings = pl_model.rate(team_ratings, ranks=ranks_list)
+
+    updates: List[Tuple[SpeakerSlot, float, float]] = []
+    for team_idx, team in enumerate(ordered_teams):
+        for player_idx, slot in enumerate(teams[team]):
+            old = float(slot.user.elo_rating or DEFAULT_MU)
+            new = float(new_ratings[team_idx][player_idx].mu)
+            slot.user.elo_rating = new
+            updates.append((slot, old, new))
+    return updates

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ SQLAlchemy==2.0.41
 typing_extensions==4.13.2
 Werkzeug==3.1.3
 Flask-SocketIO==5.3.6
+openskill==6.1.1


### PR DESCRIPTION
## Summary
- include openskill dependency
- implement BP elo calculation using Plackett–Luce model
- update finalize debate route to use new elo logic

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- Manual check with fake data via `compute_bp_elo`

------
https://chatgpt.com/codex/tasks/task_e_684dd18eb8108330b2e7c5be8fdd0c12