### PR TITLE
Add factsheet support for debate topics

### DIFF
--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -70,10 +70,11 @@ def add_topic(debate_id):
     debate = Debate.query.get_or_404(debate_id)
     if request.method == 'POST':
         text = request.form['text']
+        factsheet = request.form.get('factsheet')
         if not text:
             flash('Please enter a topic.', 'danger')
             return redirect(url_for('admin.add_topic', debate_id=debate_id))
-        topic = Topic(text=text, debate_id=debate_id)
+        topic = Topic(text=text, factsheet=factsheet, debate_id=debate_id)
         db.session.add(topic)
         db.session.commit()
         socketio.emit('topic_list_update', {'debate_id': debate_id})
@@ -187,8 +188,10 @@ def edit_topic(topic_id):
     topic = Topic.query.get_or_404(topic_id)
     if request.method == 'POST':
         text = request.form['text']
+        factsheet = request.form.get('factsheet')
         if text:
             topic.text = text
+            topic.factsheet = factsheet
             db.session.commit()
             flash('Topic updated.', 'success')
             return redirect(url_for('admin.admin_dashboard'))

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -244,7 +244,10 @@ def debate_assignments(debate_id):
 @login_required
 def debate_topics_json(debate_id):
     debate = Debate.query.get_or_404(debate_id)
-    topics = [{'id': t.id, 'text': t.text} for t in debate.topics]
+    topics = [
+        {'id': t.id, 'text': t.text, 'factsheet': t.factsheet}
+        for t in debate.topics
+    ]
     return jsonify({'topics': topics})
 
 @main_bp.route('/debate/<int:debate_id>/assignments_json')

--- a/app/models.py
+++ b/app/models.py
@@ -129,6 +129,7 @@ class Debate(db.Model):
 class Topic(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     text = db.Column(db.String(240), nullable=False)
+    factsheet = db.Column(db.Text, nullable=True)
     debate_id = db.Column(db.Integer, db.ForeignKey('debate.id'), nullable=False)
 
     # Relationship: back to debate

--- a/app/static/js/dashboard.js
+++ b/app/static/js/dashboard.js
@@ -13,7 +13,20 @@ function populateVoteBox() {
     const list = document.createElement('ul');
     topics.topics.forEach(t => {
       const li = document.createElement('li');
-      li.textContent = t.text + ' ';
+      const span = document.createElement('span');
+      span.textContent = t.text + ' ';
+      li.appendChild(span);
+      if (t.factsheet) {
+        const details = document.createElement('details');
+        details.classList.add('d-inline-block', 'ms-2');
+        const summary = document.createElement('summary');
+        summary.textContent = 'Factsheet';
+        details.appendChild(summary);
+        const div = document.createElement('div');
+        div.textContent = t.factsheet;
+        details.appendChild(div);
+        li.appendChild(details);
+      }
       if (status.user_votes.includes(t.id)) {
         const strong = document.createElement('strong');
         strong.textContent = '\u2014 You voted';

--- a/app/templates/admin/add_topic.html
+++ b/app/templates/admin/add_topic.html
@@ -4,8 +4,10 @@
 {% block content %}
 <h2>Add Topic to {{ debate.title }}</h2>
 <form method="post">
-    Topic: <input name="text"><br>
-    <input type="submit" value="Add Topic">
+    Topic: <input name="text" class="form-control mb-2"><br>
+    Factsheet:
+    <textarea name="factsheet" class="form-control mb-2" rows="4"></textarea>
+    <input type="submit" value="Add Topic" class="btn btn-primary">
 </form>
 <a href="{{ url_for('admin.admin_dashboard') }}">Back</a>
 {% endblock %}

--- a/app/templates/admin/edit_topic.html
+++ b/app/templates/admin/edit_topic.html
@@ -4,8 +4,10 @@
 {% block content %}
 <h2>Edit Topic</h2>
 <form method="post">
-    Topic: <input name="text" value="{{ topic.text }}"><br>
-    <input type="submit" value="Save">
+    Topic: <input name="text" value="{{ topic.text }}" class="form-control mb-2"><br>
+    Factsheet:
+    <textarea name="factsheet" class="form-control mb-2" rows="4">{{ topic.factsheet }}</textarea>
+    <input type="submit" value="Save" class="btn btn-primary">
 </form>
 <a href="{{ url_for('admin.admin_dashboard') }}">Back</a>
 {% endblock %}

--- a/app/templates/main/debate.html
+++ b/app/templates/main/debate.html
@@ -10,6 +10,12 @@
       {% for topic in debate.topics %}
         <li>
           {{ topic.text }}
+          {% if topic.factsheet %}
+            <details class="d-inline-block ms-2">
+              <summary>Factsheet</summary>
+              {{ topic.factsheet }}
+            </details>
+          {% endif %}
           {% if topic.id in user_votes %}
             <strong>— You voted</strong>
           {% elif votes_left > 0 %}

--- a/migrations/versions/e9db4e537b1c_add_factsheet_to_topic.py
+++ b/migrations/versions/e9db4e537b1c_add_factsheet_to_topic.py
@@ -1,0 +1,17 @@
+"""add factsheet column to topic"""
+
+revision = 'e9db4e537b1c'
+down_revision = '363076fe0622'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+def upgrade():
+    with op.batch_alter_table('topic', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('factsheet', sa.Text(), nullable=True))
+
+def downgrade():
+    with op.batch_alter_table('topic', schema=None) as batch_op:
+        batch_op.drop_column('factsheet')


### PR DESCRIPTION
## Summary
- allow admins to enter a factsheet when creating or editing a topic
- store factsheets in database
- expose factsheets via topics_json endpoint
- show factsheets in debate views and vote box
- include alembic migration for new column

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python run.py --help` (server started)

------
https://chatgpt.com/codex/tasks/task_e_6851b455bf40833081dfa544ebe3f18d