### PR TITLE
Show factsheets in dashboard vote box

### DIFF
--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -193,6 +193,7 @@ def edit_topic(topic_id):
             topic.text = text
             topic.factsheet = factsheet
             db.session.commit()
+            socketio.emit('topic_list_update', {'debate_id': topic.debate_id})
             flash('Topic updated.', 'success')
             return redirect(url_for('admin.admin_dashboard'))
         flash('Invalid input.', 'danger')
@@ -206,6 +207,7 @@ def delete_topic(topic_id):
     topic = Topic.query.get_or_404(topic_id)
     db.session.delete(topic)
     db.session.commit()
+    socketio.emit('topic_list_update', {'debate_id': topic.debate_id})
     flash('Topic deleted.', 'info')
     return redirect(url_for('admin.admin_dashboard'))
 

--- a/app/static/css/dashboard.css
+++ b/app/static/css/dashboard.css
@@ -18,3 +18,7 @@
 #graphicContainer {
   width: 100%;
 }
+
+.factsheet-content {
+  white-space: pre-wrap;
+}

--- a/app/static/js/dashboard.js
+++ b/app/static/js/dashboard.js
@@ -23,6 +23,7 @@ function populateVoteBox() {
         summary.textContent = 'Factsheet';
         details.appendChild(summary);
         const div = document.createElement('div');
+        div.classList.add('factsheet-content');
         div.textContent = t.factsheet;
         details.appendChild(div);
         li.appendChild(details);

--- a/app/templates/main/debate.html
+++ b/app/templates/main/debate.html
@@ -13,7 +13,7 @@
           {% if topic.factsheet %}
             <details class="d-inline-block ms-2">
               <summary>Factsheet</summary>
-              {{ topic.factsheet }}
+              <div class="factsheet-content">{{ topic.factsheet }}</div>
             </details>
           {% endif %}
           {% if topic.id in user_votes %}


### PR DESCRIPTION
## Summary
- show debate topic factsheets in the dashboard vote area
- keep whitespace formatting for factsheet text
- broadcast topic updates after admin edits or deletes topics

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6851b8df1184833094295a60cef65708