### PR TITLE
Add assignment mode column

### DIFF
--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -52,10 +52,12 @@ def create_debate():
     if request.method == 'POST':
         title = request.form['title']
         style = request.form['style']
+        assignment_mode = request.form.get('assignment_mode', 'Random')
         if not title or style not in ['OPD', 'BP', 'Dynamic']:
             flash('Please fill all fields correctly.', 'danger')
             return redirect(url_for('admin.create_debate'))
-        debate = Debate(title=title, style=style, active=False)
+        debate = Debate(title=title, style=style,
+                        assignment_mode=assignment_mode, active=False)
         db.session.add(debate)
         db.session.commit()
         flash('Debate created!', 'success')
@@ -159,9 +161,11 @@ def edit_debate(debate_id):
     if request.method == 'POST':
         title = request.form['title']
         style = request.form['style']
+        assignment_mode = request.form.get('assignment_mode', debate.assignment_mode)
         if title and style in ['OPD', 'BP', 'Dynamic']:
             debate.title = title
             debate.style = style
+            debate.assignment_mode = assignment_mode
             db.session.commit()
             flash('Debate updated.', 'success')
             return redirect(url_for('admin.admin_dashboard'))
@@ -284,6 +288,10 @@ def run_assign(debate_id):
     db.session.commit()
 
     scenario = request.form.get('scenario')
+    mode = request.form.get('assignment_mode')
+    if mode:
+        debate.assignment_mode = mode
+        db.session.commit()
     ok, msg = assign_speakers(debate, users, scenario=scenario)
     flash(msg, "success" if ok else "danger")
     if ok:

--- a/app/models.py
+++ b/app/models.py
@@ -30,6 +30,13 @@ class JudgeSkillEnum(db.Enum):
     wing = 'Wing'
     chair = 'Chair'
 
+# Assignment mode for distributing speakers
+class AssignmentModeEnum(db.Enum):
+    true_random = 'True random'
+    random = 'Random'
+    skill_based = 'Skill based'
+    pro_am = 'ProAm'
+
 
 class PendingUser(db.Model):
     id = db.Column(db.Integer, primary_key=True)
@@ -109,6 +116,16 @@ class Debate(db.Model):
     style = db.Column(
         db.Enum('OPD', 'BP', 'Dynamic', name='debate_style'),
         nullable=False
+    )
+    assignment_mode = db.Column(
+        db.Enum(
+            'True random',
+            'Random',
+            'Skill based',
+            'ProAm',
+            name='assignment_mode'
+        ),
+        default='Random'
     )
     voting_open = db.Column(db.Boolean, default=True)
     active = db.Column(db.Boolean, default=False)

--- a/app/templates/admin/create_debate.html
+++ b/app/templates/admin/create_debate.html
@@ -18,6 +18,15 @@
                 <option value="Dynamic">Dynamic</option>
             </select>
         </div>
+        <div class="mb-3">
+            <label for="assignment_mode" class="form-label">Assignment Mode:</label>
+            <select id="assignment_mode" name="assignment_mode" class="form-select">
+                <option value="True random">True random</option>
+                <option value="Random" selected>Random</option>
+                <option value="Skill based">Skill based</option>
+                <option value="ProAm">ProAm</option>
+            </select>
+        </div>
         <button type="submit" class="btn btn-success">Create</button>
         <a href="{{ url_for('admin.admin_dashboard') }}" class="btn btn-link">Back</a>
     </form>

--- a/app/templates/admin/dynamic_plan.html
+++ b/app/templates/admin/dynamic_plan.html
@@ -14,6 +14,15 @@
   <h4 class="mt-4">Possible Scenarios</h4>
   {% if scenarios %}
   <form method="post" action="{{ url_for('admin.run_assign', debate_id=debate.id) }}">
+    <div class="mb-3">
+      <label for="assignment_mode" class="form-label">Assignment Mode</label>
+      <select id="assignment_mode" name="assignment_mode" class="form-select">
+        <option value="True random" {% if debate.assignment_mode == 'True random' %}selected{% endif %}>True random</option>
+        <option value="Random" {% if debate.assignment_mode == 'Random' %}selected{% endif %}>Random</option>
+        <option value="Skill based" {% if debate.assignment_mode == 'Skill based' %}selected{% endif %}>Skill based</option>
+        <option value="ProAm" {% if debate.assignment_mode == 'ProAm' %}selected{% endif %}>ProAm</option>
+      </select>
+    </div>
     {% for sc in scenarios %}
     <div class="form-check">
       <input class="form-check-input" type="radio" name="scenario" id="sc{{ loop.index }}" value="{{ sc.id }}" {% if loop.first %}checked{% endif %}>

--- a/app/templates/admin/edit_debate.html
+++ b/app/templates/admin/edit_debate.html
@@ -11,6 +11,13 @@
         <option value="BP" {% if debate.style == "BP" %}selected{% endif %}>BP</option>
         <option value="Dynamic" {% if debate.style == "Dynamic" %}selected{% endif %}>Dynamic</option>
     </select><br>
+    Assignment Mode:
+    <select name="assignment_mode">
+        <option value="True random" {% if debate.assignment_mode == 'True random' %}selected{% endif %}>True random</option>
+        <option value="Random" {% if debate.assignment_mode == 'Random' %}selected{% endif %}>Random</option>
+        <option value="Skill based" {% if debate.assignment_mode == 'Skill based' %}selected{% endif %}>Skill based</option>
+        <option value="ProAm" {% if debate.assignment_mode == 'ProAm' %}selected{% endif %}>ProAm</option>
+    </select><br>
     <input type="submit" value="Save">
 </form>
 <a href="{{ url_for('admin.admin_dashboard') }}">Back</a>

--- a/migrations/versions/c05d7f1446ab_add_assignment_mode_to_debate.py
+++ b/migrations/versions/c05d7f1446ab_add_assignment_mode_to_debate.py
@@ -1,0 +1,25 @@
+"""add assignment_mode column to debate
+
+Revision ID: c05d7f1446ab
+Revises: 363076fe0622
+Create Date: 2025-07-01 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'c05d7f1446ab'
+down_revision = '363076fe0622'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('debate', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('assignment_mode', sa.Enum('True random', 'Random', 'Skill based', 'ProAm', name='assignment_mode'), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table('debate', schema=None) as batch_op:
+        batch_op.drop_column('assignment_mode')


### PR DESCRIPTION
## Summary
- extend Debate model with `assignment_mode`
- collect assignment mode when creating or editing debates
- show the mode in the dynamic planning view
- create alembic migration for assignment mode

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851b37bddcc833088483e2cdaf2335a