### PR TITLE
Implement tie-break second voting

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -28,10 +28,16 @@ def dashboard():
     is_judge_chair = False
 
     if current_debate:
-        # Get topic IDs for this debate
-        topic_ids = [t.id for t in current_debate.topics]
-        # Get all votes for these topics
-        votes = Vote.query.filter(Vote.topic_id.in_(topic_ids)).all()
+        if current_debate.second_voting_open:
+            topic_ids = current_debate.second_topic_ids()
+            round_num = 2
+        else:
+            topic_ids = [t.id for t in current_debate.topics]
+            round_num = 1
+        votes = Vote.query.filter(
+            Vote.topic_id.in_(topic_ids),
+            Vote.round == round_num
+        ).all()
         voter_ids = set(v.user_id for v in votes)
         votes_cast = len(voter_ids)
 
@@ -76,6 +82,7 @@ def dashboard():
         single_open=current_debate,
         has_slot=has_slot,
         is_judge_chair=is_judge_chair,
+        second_voting_open=current_debate.second_voting_open if current_debate else False,
     )
 
 
@@ -96,13 +103,22 @@ def dashboard_debates_json():
             'title': d.title,
             'style': d.style,
             'active': d.active,
+            'second_voting_open': d.second_voting_open,
         } if d else None
 
     def serialize_current(d):
         if not d:
             return None
-        topic_ids = [t.id for t in d.topics]
-        votes = Vote.query.filter(Vote.topic_id.in_(topic_ids)).all()
+        if d.second_voting_open:
+            topic_ids = d.second_topic_ids()
+            round_num = 2
+        else:
+            topic_ids = [t.id for t in d.topics]
+            round_num = 1
+        votes = Vote.query.filter(
+            Vote.topic_id.in_(topic_ids),
+            Vote.round == round_num
+        ).all()
         voter_ids = set(v.user_id for v in votes)
         votes_cast = len(voter_ids)
 
@@ -130,6 +146,7 @@ def dashboard_debates_json():
             'style': d.style,
             'active': d.active,
             'voting_open': d.voting_open,
+            'second_voting_open': d.second_voting_open,
             'assignment_complete': d.assignment_complete,
             'user_role': user_role,
             'is_judge_chair': is_judge_chair,
@@ -153,30 +170,34 @@ def debate_view(debate_id):
         return redirect(url_for('auth.survey'))
 
     debate = Debate.query.options(joinedload(Debate.speakerslots)).get_or_404(debate_id)
-    topics = debate.topics  # adjust as needed
+    topics = debate.second_topics() if debate.second_voting_open else debate.topics
 
     # voting logic
     if request.method == 'POST' and debate.voting_open:
         topic_id = int(request.form.get('topic_id'))
-        # Check if user already voted for this topic
-        existing_vote = Vote.query.filter_by(user_id=current_user.id, topic_id=topic_id).first()
-        # Count how many topics user already voted for in this debate
+        round_num = 2 if debate.second_voting_open else 1
+        existing_vote = Vote.query.filter_by(user_id=current_user.id, topic_id=topic_id, round=round_num).first()
         user_votes_in_debate = Vote.query.join(Topic).filter(
             Vote.user_id == current_user.id,
-            Topic.debate_id == debate_id
+            Topic.debate_id == debate_id,
+            Vote.round == round_num
         ).count()
+        max_votes = 1 if debate.second_voting_open else 2
         if existing_vote:
             flash('You have already voted for this topic.', 'warning')
-        elif user_votes_in_debate >= 2:
-            flash('You can only vote for up to 2 topics per debate.', 'danger')
+        elif user_votes_in_debate >= max_votes:
+            if debate.second_voting_open:
+                flash('You can only vote for one topic in this round.', 'danger')
+            else:
+                flash('You can only vote for up to 2 topics per debate.', 'danger')
         else:
             # Bump debate_count if this is their first vote in this debate
             
-            if user_votes_in_debate == 0:
+            if user_votes_in_debate == 0 and round_num == 1:
                 if current_user.debate_count is None:
                     current_user.debate_count = 0
                 current_user.debate_count += 1
-            vote = Vote(user_id=current_user.id, topic_id=topic_id)
+            vote = Vote(user_id=current_user.id, topic_id=topic_id, round=round_num)
             db.session.add(vote)
             db.session.commit()
             
@@ -191,7 +212,7 @@ def debate_view(debate_id):
                 row[0]
                 for row in db.session.query(Vote.user_id)
                 .join(Topic)
-                .filter(Topic.debate_id == debate_id)
+                .filter(Topic.debate_id == debate_id, Vote.round == round_num)
                 .distinct()
                 .all()
             )
@@ -212,11 +233,15 @@ def debate_view(debate_id):
         return redirect(url_for('main.debate_view', debate_id=debate_id))
 
     # Prepare user vote info for template
-    user_votes = [vote.topic_id for vote in Vote.query.filter_by(user_id=current_user.id).all()]
-    votes_left = 2 - Vote.query.join(Topic).filter(
+    round_num = 2 if debate.second_voting_open else 1
+    topic_ids = debate.second_topic_ids() if debate.second_voting_open else [t.id for t in debate.topics]
+    user_votes = [v.topic_id for v in Vote.query.filter(
         Vote.user_id == current_user.id,
-        Topic.debate_id == debate_id
-    ).count()
+        Vote.round == round_num,
+        Vote.topic_id.in_(topic_ids)
+    ).all()]
+    limit = 1 if debate.second_voting_open else 2
+    votes_left = limit - len(user_votes)
 
     return render_template('main/debate.html',
                            debate=debate,
@@ -244,9 +269,10 @@ def debate_assignments(debate_id):
 @login_required
 def debate_topics_json(debate_id):
     debate = Debate.query.get_or_404(debate_id)
+    topic_list = debate.second_topics() if debate.second_voting_open else debate.topics
     topics = [
         {'id': t.id, 'text': t.text, 'factsheet': t.factsheet}
-        for t in debate.topics
+        for t in topic_list
     ]
     return jsonify({'topics': topics})
 
@@ -284,12 +310,20 @@ def debate_assignments_json(debate_id):
 @login_required
 def debate_vote_status_json(debate_id):
     debate = Debate.query.get_or_404(debate_id)
-    topic_ids = [t.id for t in debate.topics]
+    if debate.second_voting_open:
+        round_num = 2
+        topic_ids = debate.second_topic_ids()
+        limit = 1
+    else:
+        round_num = 1
+        topic_ids = [t.id for t in debate.topics]
+        limit = 2
     user_votes = [v.topic_id for v in Vote.query.filter(
         Vote.user_id == current_user.id,
+        Vote.round == round_num,
         Vote.topic_id.in_(topic_ids)
     ).all()]
-    votes_left = 2 - len(user_votes)
+    votes_left = limit - len(user_votes)
     return jsonify({'user_votes': user_votes, 'votes_left': votes_left})
 
 @main_bp.route('/debate/<int:debate_id>/graphic')

--- a/app/static/js/dashboard.js
+++ b/app/static/js/dashboard.js
@@ -272,6 +272,9 @@ socket.on('debate_status', data => {
   } else {
     cont.style.display = 'none';
   }
+  if (typeof data.second_voting_open !== 'undefined') {
+    window.secondVotingOpen = data.second_voting_open;
+  }
 });
 
 socket.on('assignments_ready', data => {
@@ -344,6 +347,7 @@ function updateCurrentDebate(data) {
 
   window.currentDebateId = data ? data.id : null;
   window.votingOpen = data ? data.voting_open : false;
+  window.secondVotingOpen = data ? data.second_voting_open : false;
   window.assignmentsComplete = data ? data.assignment_complete : false;
   window.currentDebateStyle = data ? data.style : '';
   window.userHasSlot = data && data.user_role ? true : false;

--- a/app/templates/admin/dashboard.html
+++ b/app/templates/admin/dashboard.html
@@ -40,6 +40,9 @@
             <a href="{{ url_for('admin.toggle_voting', debate_id=debate.id) }}" class="btn btn-outline-warning btn-sm flex-fill flex-md-grow-0">
               {% if debate.voting_open %}Close Voting{% else %}Open Voting{% endif %}
             </a>
+            {% if debate.second_voting_topics and not debate.second_voting_open %}
+            <a href="{{ url_for('admin.open_second_voting', debate_id=debate.id) }}" class="btn btn-outline-warning btn-sm flex-fill flex-md-grow-0">Open Second Voting</a>
+            {% endif %}
             <a href="{{ url_for('admin.toggle_active', debate_id=debate.id) }}" class="btn btn-outline-secondary btn-sm flex-fill flex-md-grow-0">
               {% if debate.active %}Set Inactive{% else %}Set Active{% endif %}
             </a>

--- a/app/templates/main/dashboard.html
+++ b/app/templates/main/dashboard.html
@@ -10,6 +10,7 @@
 <script>
   window.currentDebateId = {{ current_debate.id if current_debate else 'null' }};
   window.votingOpen = {{ 'true' if current_debate and current_debate.voting_open else 'false' }};
+  window.secondVotingOpen = {{ 'true' if current_debate and second_voting_open else 'false' }};
   window.assignmentsComplete = {{ 'true' if current_debate and current_debate.assignment_complete else 'false' }};
   window.currentDebateStyle = "{{ current_debate.style if current_debate else '' }}";
   window.currentUserId = {{ current_user.id }};

--- a/migrations/versions/abcdef123456_second_voting.py
+++ b/migrations/versions/abcdef123456_second_voting.py
@@ -1,0 +1,29 @@
+"""add second voting support"""
+
+revision = 'abcdef123456'
+down_revision = 'c05d7f1446ab'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    with op.batch_alter_table('debate', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('second_voting_open', sa.Boolean(), nullable=True, server_default=sa.text('0')))
+        batch_op.add_column(sa.Column('second_voting_topics', sa.String(), nullable=True))
+    with op.batch_alter_table('vote', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('round', sa.Integer(), nullable=True, server_default='1'))
+        batch_op.drop_constraint('_user_topic_uc', type_='unique')
+        batch_op.create_unique_constraint('_user_topic_round_uc', ['user_id', 'topic_id', 'round'])
+
+
+def downgrade():
+    with op.batch_alter_table('vote', schema=None) as batch_op:
+        batch_op.drop_constraint('_user_topic_round_uc', type_='unique')
+        batch_op.create_unique_constraint('_user_topic_uc', ['user_id', 'topic_id'])
+        batch_op.drop_column('round')
+    with op.batch_alter_table('debate', schema=None) as batch_op:
+        batch_op.drop_column('second_voting_topics')
+        batch_op.drop_column('second_voting_open')


### PR DESCRIPTION
## Summary
- add second voting state to debates and extend votes with a `round`
- allow admin to open second voting after closing round one
- show second voting button on the admin dashboard
- adapt user routes/APIs and dashboard JS for second round behaviour
- provide DB migration for new columns

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6851c65003a08330a89216c531e2df2b