### PR TITLE
Display winning topic factsheet

### DIFF
--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -112,7 +112,11 @@ def toggle_voting(debate_id):
         if winner:
             socketio.emit('winning_topic', {
                 'debate_id': debate_id,
-                'topic': {'id': winner.id, 'text': winner.text}
+                'topic': {
+                    'id': winner.id,
+                    'text': winner.text,
+                    'factsheet': winner.factsheet,
+                }
             })
     socketio.emit('debate_status', {
         'debate_id': debate_id,

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -159,7 +159,11 @@ def dashboard_debates_json():
             'vote_percent': vote_percent,
             'votes_cast': votes_cast,
             'votes_total': votes_total,
-            'winner_topic': {'id': winner.id, 'text': winner.text} if winner else None,
+            'winner_topic': {
+                'id': winner.id,
+                'text': winner.text,
+                'factsheet': winner.factsheet,
+            } if winner else None,
         }
 
     return jsonify({

--- a/app/static/js/dashboard.js
+++ b/app/static/js/dashboard.js
@@ -297,12 +297,22 @@ socket.on('topic_list_update', data => {
 socket.on('winning_topic', data => {
   if (data.debate_id !== window.currentDebateId) return;
   const winEl = document.getElementById('winningTopic');
+  const factEl = document.getElementById('winningFactsheet');
   if (winEl) {
     if (data.topic) {
       winEl.textContent = `Winning topic: ${data.topic.text}`;
       winEl.style.display = 'block';
+      if (factEl) {
+        if (data.topic.factsheet) {
+          factEl.textContent = data.topic.factsheet;
+          factEl.style.display = 'block';
+        } else {
+          factEl.style.display = 'none';
+        }
+      }
     } else {
       winEl.style.display = 'none';
+      if (factEl) factEl.style.display = 'none';
     }
   }
 });
@@ -354,12 +364,22 @@ function updateCurrentDebate(data) {
   }
 
   const winEl = document.getElementById('winningTopic');
+  const factEl = document.getElementById('winningFactsheet');
   if (winEl) {
     if (data && data.winner_topic) {
       winEl.textContent = `Winning topic: ${data.winner_topic.text}`;
       winEl.style.display = 'block';
+      if (factEl) {
+        if (data.winner_topic.factsheet) {
+          factEl.textContent = data.winner_topic.factsheet;
+          factEl.style.display = 'block';
+        } else {
+          factEl.style.display = 'none';
+        }
+      }
     } else {
       winEl.style.display = 'none';
+      if (factEl) factEl.style.display = 'none';
     }
   }
 

--- a/app/templates/main/dashboard.html
+++ b/app/templates/main/dashboard.html
@@ -45,6 +45,9 @@
         <small class="text-muted">{{ votes_cast or 0 }}/{{ votes_total or 0 }} have voted</small>
         <small class="text-muted">{{ vote_percent or 0 }}%</small>
       </div>
+      <p id="winningFactsheet" class="mt-2 small text-muted factsheet-content"{% if not winning_topic or not winning_topic.factsheet %} style="display:none"{% endif %}>
+        {% if winning_topic and winning_topic.factsheet %}{{ winning_topic.factsheet }}{% endif %}
+      </p>
       <p id="winningTopic" class="mt-2 fw-bold text-success"{% if not winning_topic %} style="display:none"{% endif %}>
         {% if winning_topic %}Winning topic: {{ winning_topic.text }}{% endif %}
       </p>


### PR DESCRIPTION
## Summary
- include factsheet in `winning_topic` socket payload and JSON
- show the factsheet above the winning topic on dashboard
- update JS handlers for live factsheet display

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851d0f4fd00833087c73093bc78d39a