### PR TITLE
Round BP Elo ratings

### DIFF
--- a/app/logic/elo.py
+++ b/app/logic/elo.py
@@ -34,7 +34,7 @@ def compute_bp_elo(slots: List[SpeakerSlot], ranks: Dict[str, int]) -> List[Tupl
         for player_idx, slot in enumerate(teams[team]):
             old_mu = float(slot.user.elo_rating or DEFAULT_MU)
             old_sigma = float(getattr(slot.user, 'elo_sigma', DEFAULT_SIGMA) or DEFAULT_SIGMA)
-            new_mu = float(new_ratings[team_idx][player_idx].mu)
+            new_mu = round(float(new_ratings[team_idx][player_idx].mu), 2)
             new_sigma = float(new_ratings[team_idx][player_idx].sigma)
             slot.user.elo_rating = new_mu
             if hasattr(slot.user, 'elo_sigma'):

--- a/app/templates/profile/view.html
+++ b/app/templates/profile/view.html
@@ -21,7 +21,7 @@
 <p><strong>Debate Skill:</strong> {{ current_user.debate_skill or '—' }}</p>
 <p><strong>Judge Skill:</strong> {{ current_user.judge_skill or '—' }}</p>
 <p><strong>Debates Participated:</strong> {{ current_user.debate_count or 0 }}</p>
-<p><strong>BP Ranking:</strong> {{ current_user.elo_rating }} &plusmn; {{ '%.1f'|format(current_user.elo_sigma) }}</p>
+<p><strong>BP Ranking:</strong> {{ '%.0f'|format(current_user.elo_rating) }} &plusmn; {{ '%.1f'|format(current_user.elo_sigma) }}</p>
 <p><strong>OPD Skill:</strong>
   {% if opd_result_count == 0 %}
     None
@@ -38,7 +38,7 @@
     <li class="list-group-item debate-item" style="display:none;">
       <strong>{{ item.debate.title }}</strong> ({{ item.debate.style }}) -
       {% if item.debate.style == 'BP' %}
-        Place {{ item.rank or '?' }}, Elo {{ '%+.1f'|format(item.elo_change or 0) }}
+        Place {{ item.rank or '?' }}, Elo {{ '%+.0f'|format(item.elo_change or 0) }}
       {% else %}
         {{ '%.1f pts'|format(item.points) }}
       {% endif %}


### PR DESCRIPTION
## Summary
- round Elo rating for BP debates to two decimals
- show only whole numbers in profile Elo display

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68532192862c8330918d09783ccae405