### PR TITLE
Improve profile results view

### DIFF
--- a/app/profile/routes.py
+++ b/app/profile/routes.py
@@ -2,6 +2,7 @@ from flask import render_template, request, redirect, url_for, flash
 from flask_login import login_required, current_user
 from app.extensions import db
 from app.models import OpdResult, Debate, EloLog, SpeakerSlot, BpRank
+from sqlalchemy.sql import func
 from . import profile_bp
 
 @profile_bp.route('/profile', methods=['GET', 'POST'])
@@ -24,22 +25,77 @@ def view():
 
     opd_result_count = current_user.opd_result_count()
 
-    results = OpdResult.query.filter_by(user_id=current_user.id).order_by(
-        OpdResult.id.desc()
-    ).limit(20).all()
+    results = (
+        OpdResult.query.filter_by(user_id=current_user.id)
+        .order_by(OpdResult.id.desc())
+        .limit(20)
+        .all()
+    )
+
     recent_debates = []
     for res in results:
         debate = Debate.query.get(res.debate_id)
-        log = EloLog.query.filter_by(debate_id=res.debate_id, user_id=current_user.id).first()
+        log = EloLog.query.filter_by(
+            debate_id=res.debate_id, user_id=current_user.id
+        ).first()
         change = log.change if log else 0
         rank = None
-        if debate.style == 'BP':
-            slot = SpeakerSlot.query.filter_by(debate_id=res.debate_id, user_id=current_user.id).first()
-            team = slot.role.split('-')[0] if slot else None
+        win = None
+
+        slot = SpeakerSlot.query.filter_by(
+            debate_id=res.debate_id, user_id=current_user.id
+        ).first()
+        role = slot.role.split('-')[0] if slot else None
+
+        if debate.style == "BP":
+            team = role
             if team:
-                bp = BpRank.query.filter_by(debate_id=res.debate_id, team=team).first()
+                bp = BpRank.query.filter_by(
+                    debate_id=res.debate_id, team=team
+                ).first()
                 if bp:
                     rank = bp.rank
-        recent_debates.append({'debate': debate, 'points': res.points, 'elo_change': change, 'rank': rank})
+        elif debate.style == "OPD" and role in ("Gov", "Opp"):
+            gov_total = (
+                db.session.query(func.sum(OpdResult.points))
+                .join(
+                    SpeakerSlot,
+                    (OpdResult.debate_id == SpeakerSlot.debate_id)
+                    & (OpdResult.user_id == SpeakerSlot.user_id),
+                )
+                .filter(
+                    OpdResult.debate_id == res.debate_id,
+                    SpeakerSlot.role.startswith("Gov"),
+                )
+                .scalar()
+                or 0
+            )
+            opp_total = (
+                db.session.query(func.sum(OpdResult.points))
+                .join(
+                    SpeakerSlot,
+                    (OpdResult.debate_id == SpeakerSlot.debate_id)
+                    & (OpdResult.user_id == SpeakerSlot.user_id),
+                )
+                .filter(
+                    OpdResult.debate_id == res.debate_id,
+                    SpeakerSlot.role.startswith("Opp"),
+                )
+                .scalar()
+                or 0
+            )
+            if gov_total != opp_total:
+                winning = "Gov" if gov_total > opp_total else "Opp"
+                win = role == winning
+
+        recent_debates.append(
+            {
+                "debate": debate,
+                "points": res.points,
+                "elo_change": change,
+                "rank": rank,
+                "win": win,
+            }
+        )
 
     return render_template('profile/view.html', opd_result_count=opd_result_count, recent_debates=recent_debates)

--- a/app/templates/profile/view.html
+++ b/app/templates/profile/view.html
@@ -38,9 +38,19 @@
     <li class="list-group-item debate-item" style="display:none;">
       <strong>{{ item.debate.title }}</strong> ({{ item.debate.style }}) -
       {% if item.debate.style == 'BP' %}
-        Place {{ item.rank or '?' }}, Elo {{ '%+.0f'|format(item.elo_change or 0) }}
+        {% set colors = {1:'primary',2:'success',3:'warning text-dark',4:'danger'} %}
+        {% set labels = {1:'1st',2:'2nd',3:'3rd',4:'4th'} %}
+        {% if item.rank %}
+          <span class="badge bg-{{ colors.get(item.rank, 'secondary') }}">{{ labels.get(item.rank, item.rank ~ 'th') }}</span>
+        {% else %}
+          <span class="badge bg-secondary">?</span>
+        {% endif %}
+        , Elo {{ '%+.0f'|format(item.elo_change or 0) }}
       {% else %}
-        {{ '%.1f pts'|format(item.points) }}
+        {% if item.win is not none %}
+          <span class="badge bg-{{ 'success' if item.win else 'danger' }}">{{ 'Won' if item.win else 'Lost' }}</span>
+        {% endif %}
+        {{ ' %.1f pts'|format(item.points) }}
       {% endif %}
     </li>
   {% endfor %}


### PR DESCRIPTION
## Summary
- enhance profile BP result display to use rank badges
- compute win/loss info for OPD results
- show OPD win or loss badge

## Testing
- `python -m py_compile app/profile/routes.py`
- `pip install -q -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_685327063c048330b5050a906b49baca