### PR TITLE
Add debate results view

### DIFF
--- a/app/templates/profile/debate_results.html
+++ b/app/templates/profile/debate_results.html
@@ -1,0 +1,57 @@
+{% extends "base.html" %}
+{% block title %}Results: {{ debate.title }}{% endblock %}
+{% block content %}
+<h2 class="mb-4">Results for {{ debate.title }}</h2>
+
+{% for room in slots_by_room.keys()|sort %}
+  <h4 class="mt-3">Room {{ room }} ({{ room_styles[room] }})</h4>
+  {% if room_styles[room] == 'BP' %}
+    <div class="table-responsive">
+      <table class="table table-bordered align-middle">
+        <thead class="table-light">
+          <tr><th>Team</th><th>Speakers</th><th>Rank</th></tr>
+        </thead>
+        <tbody>
+        {% for team in ['OG','OO','CG','CO'] %}
+          <tr>
+            <td>{{ team }}</td>
+            <td>
+              {% set slots = slots_by_room[room]|selectattr('role','equalto',team)|list %}
+              {% if slots %}
+                {% for slot in slots %}
+                  {{ user_map[slot.user_id].first_name }} {{ user_map[slot.user_id].last_name }}<br>
+                {% endfor %}
+              {% else %}
+                <em>&mdash;</em>
+              {% endif %}
+            </td>
+            <td>{{ bp_ranks.get(team) or '?' }}</td>
+          </tr>
+        {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  {% else %}
+    <div class="table-responsive">
+      <table class="table table-bordered align-middle">
+        <thead class="table-light">
+          <tr><th>Role</th><th>Name</th><th>Points</th></tr>
+        </thead>
+        <tbody>
+        {% for slot in slots_by_room[room] if not slot.role.startswith('Judge') %}
+          <tr>
+            <td>{{ slot.role }}</td>
+            <td>{{ user_map[slot.user_id].first_name }} {{ user_map[slot.user_id].last_name }}</td>
+            <td>{{ '%.1f'|format(opd_points.get(slot.user_id, 0)) }}</td>
+          </tr>
+        {% endfor %}
+        </tbody>
+      </table>
+    </div>
+    <p><strong>Gov Total:</strong> {{ '%.1f'|format(gov_total.get(room,0)) }} &nbsp;
+       <strong>Opp Total:</strong> {{ '%.1f'|format(opp_total.get(room,0)) }}</p>
+  {% endif %}
+{% endfor %}
+
+<a href="{{ url_for('profile.view') }}" class="btn btn-secondary mt-4">Back to Profile</a>
+{% endblock %}

--- a/app/templates/profile/view.html
+++ b/app/templates/profile/view.html
@@ -35,8 +35,9 @@
 <h5 class="mt-4">Recent Debates</h5>
 <ul id="debateList" class="list-group mb-2">
   {% for item in recent_debates %}
-    <li class="list-group-item debate-item" style="display:none;">
-      <strong>{{ item.debate.title }}</strong> ({{ item.debate.style }}) -
+    <li class="list-group-item debate-item d-flex justify-content-between align-items-center" style="display:none;">
+      <span>
+        <strong>{{ item.debate.title }}</strong> ({{ item.debate.style }}) -
       {% if item.debate.style == 'BP' %}
         {% set colors = {1:'primary',2:'success',3:'warning text-dark',4:'danger'} %}
         {% set labels = {1:'1st',2:'2nd',3:'3rd',4:'4th'} %}
@@ -52,6 +53,8 @@
         {% endif %}
         {{ ' %.1f pts'|format(item.points) }}
       {% endif %}
+      </span>
+      <a href="{{ url_for('profile.debate_results', debate_id=item.debate.id) }}" class="btn btn-outline-primary btn-sm">Results</a>
     </li>
   {% endfor %}
 </ul>


### PR DESCRIPTION
## Summary
- add endpoint to view detailed results for past debates
- show points or ranks for each room in new template
- link to new results page from profile's recent debate list

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68532982aaa08330bc9c9ebc5ed87c29