### PR TITLE
Allow admin editing of user skills and elo

### DIFF
--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -323,6 +323,33 @@ def toggle_user_admin(user_id):
     db.session.commit()
     flash(f"User '{user.first_name} {user.last_name}' admin status changed.", "info")
     return redirect(url_for('admin.manage_users'))
+
+
+@admin_bp.route('/admin/users/<int:user_id>/edit', methods=['GET', 'POST'])
+@login_required
+@admin_required
+def edit_user(user_id):
+    from app.models import User
+    user = User.query.get_or_404(user_id)
+    if request.method == 'POST':
+        user.debate_skill = request.form.get('debate_skill') or None
+        user.judge_skill = request.form.get('judge_skill') or None
+        elo = request.form.get('elo_rating')
+        sigma = request.form.get('elo_sigma')
+        try:
+            if elo:
+                user.elo_rating = float(elo)
+        except ValueError:
+            flash('Invalid Elo rating.', 'danger')
+        try:
+            if sigma:
+                user.elo_sigma = float(sigma)
+        except ValueError:
+            flash('Invalid Elo sigma.', 'danger')
+        db.session.commit()
+        flash('User updated.', 'success')
+        return redirect(url_for('admin.manage_users'))
+    return render_template('admin/edit_user.html', user=user)
     
 @admin_bp.route('/admin/<int:debate_id>/assign', methods=['POST'])
 @login_required

--- a/app/templates/admin/edit_user.html
+++ b/app/templates/admin/edit_user.html
@@ -1,0 +1,33 @@
+{% extends "base.html" %}
+{% block title %}Edit User{% endblock %}
+{% block content %}
+<h2>Edit User</h2>
+<form method="post" class="mb-3">
+    <div class="mb-3">
+        <label class="form-label">Debate Skill</label>
+        <select name="debate_skill" class="form-select">
+            {% for skill in ['First Timer','Beginner','Intermediate','Advanced','Expert'] %}
+            <option value="{{ skill }}" {% if user.debate_skill==skill %}selected{% endif %}>{{ skill }}</option>
+            {% endfor %}
+        </select>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Judge Skill</label>
+        <select name="judge_skill" class="form-select">
+            {% for skill in ['Cant judge','Wing','Chair'] %}
+            <option value="{{ skill }}" {% if user.judge_skill==skill %}selected{% endif %}>{{ skill }}</option>
+            {% endfor %}
+        </select>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">BP Elo</label>
+        <input type="number" step="any" name="elo_rating" class="form-control" value="{{ '%.2f'|format(user.elo_rating) if user.elo_rating is not none else '' }}">
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Sigma</label>
+        <input type="number" step="any" name="elo_sigma" class="form-control" value="{{ '%.2f'|format(user.elo_sigma) if user.elo_sigma is not none else '' }}">
+    </div>
+    <button type="submit" class="btn btn-primary">Save</button>
+    <a href="{{ url_for('admin.manage_users') }}" class="btn btn-link">Back</a>
+</form>
+{% endblock %}

--- a/app/templates/admin/users.html
+++ b/app/templates/admin/users.html
@@ -41,6 +41,7 @@
                 {% if user.is_admin %}Revoke Admin{% else %}Make Admin{% endif %}
             </button>
         </form>
+        <a href="{{ url_for('admin.edit_user', user_id=user.id) }}" class="btn btn-sm btn-primary ms-1">Edit</a>
       </td>
     </tr>
     {% endfor %}


### PR DESCRIPTION
## Summary
- add route and form to edit user debate skill, judge skill and ELO
- link to edit user page from user management table

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68532e253fa883309f13cb101badfe14