### PR TITLE
Update welcome survey with new questions and language field

### DIFF
--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -334,6 +334,7 @@ def edit_user(user_id):
     if request.method == 'POST':
         user.debate_skill = request.form.get('debate_skill') or None
         user.judge_skill = request.form.get('judge_skill') or None
+        user.languages = request.form.get('languages') or None
         elo = request.form.get('elo_rating')
         sigma = request.form.get('elo_sigma')
         try:

--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -136,13 +136,23 @@ def survey():
 
     if request.method == 'POST':
         date_joined_choice = request.form.get('date_joined_choice')
-        judge_choice = request.form.get('judge_choice')
-        if not date_joined_choice or not judge_choice:
+        languages = request.form.getlist('languages')
+        chair_conf = request.form.get('chair_confidence')
+        wing_conf = request.form.get('wing_confidence')
+        if not date_joined_choice or not chair_conf or not wing_conf:
             flash('Please answer all questions!', 'danger')
             return render_template('auth/survey.html')
 
+        if chair_conf in ('very', 'rather'):
+            judge_choice = 'chair'
+        elif wing_conf in ('very', 'rather'):
+            judge_choice = 'wing'
+        else:
+            judge_choice = 'no'
+
         current_user.date_joined_choice = date_joined_choice
         current_user.judge_choice = judge_choice
+        current_user.languages = ','.join(languages)
         apply_skills(current_user)
         db.session.commit()
         flash('Thanks for your answers! Your skills have been set.', 'success')

--- a/app/models.py
+++ b/app/models.py
@@ -57,6 +57,7 @@ class User(UserMixin, db.Model):
     is_admin = db.Column(db.Boolean, default=False)
     date_joined_choice = db.Column(db.String(16), nullable=True)   # stores survey radio answer
     judge_choice = db.Column(db.String(8), nullable=True)          # stores survey radio answer
+    languages = db.Column(db.String(64), nullable=True)            # comma separated list of languages
     debate_skill = db.Column(db.String(24), nullable=True)
     judge_skill = db.Column(db.String(16), nullable=True)
     debate_count = db.Column(db.Integer, default=0)

--- a/app/profile/routes.py
+++ b/app/profile/routes.py
@@ -11,16 +11,19 @@ from . import profile_bp
 @login_required
 def view():
     if request.method == 'POST':
-        # Allow editing name and email only
+        # Allow editing name, email and languages
         first_name = request.form.get('first_name')
         last_name = request.form.get('last_name')
         email = request.form.get('email')
+        languages = request.form.get('languages')
         if first_name and first_name != current_user.first_name:
             current_user.first_name = first_name
         if last_name is not None and last_name != current_user.last_name:
             current_user.last_name = last_name
         if email and email != current_user.email:
             current_user.email = email
+        if languages is not None and languages != current_user.languages:
+            current_user.languages = languages
         db.session.commit()
         flash('Profile updated.', 'success')
         return redirect(url_for('profile.view'))

--- a/app/templates/admin/edit_user.html
+++ b/app/templates/admin/edit_user.html
@@ -20,6 +20,10 @@
         </select>
     </div>
     <div class="mb-3">
+        <label class="form-label">Languages</label>
+        <input name="languages" class="form-control" value="{{ user.languages }}">
+    </div>
+    <div class="mb-3">
         <label class="form-label">BP Elo</label>
         <input type="number" step="any" name="elo_rating" class="form-control" value="{{ '%.2f'|format(user.elo_rating) if user.elo_rating is not none else '' }}">
     </div>

--- a/app/templates/auth/survey.html
+++ b/app/templates/auth/survey.html
@@ -32,18 +32,66 @@
     </div>
 
     <div class="mb-3">
-        <label class="form-label"><strong>Judging: Would you wing or chair a debate?</strong></label>
+        <label class="form-label"><strong>In which languages can you debate?</strong></label>
         <div class="form-check">
-            <input class="form-check-input" type="radio" name="judge_choice" id="nojudge" value="no">
-            <label class="form-check-label" for="nojudge">No</label>
+            <input class="form-check-input" type="checkbox" name="languages" id="lang_de" value="German">
+            <label class="form-check-label" for="lang_de">German</label>
         </div>
         <div class="form-check">
-            <input class="form-check-input" type="radio" name="judge_choice" id="wing" value="wing">
-            <label class="form-check-label" for="wing">Wing</label>
+            <input class="form-check-input" type="checkbox" name="languages" id="lang_en" value="English">
+            <label class="form-check-label" for="lang_en">English</label>
+        </div>
+    </div>
+
+    <div class="mb-3">
+        <label class="form-label"><strong>Did you attend a debating tournament?</strong></label>
+        <div class="form-check">
+            <input class="form-check-input" type="radio" name="tournament" id="tourn_no" value="no">
+            <label class="form-check-label" for="tourn_no">No</label>
         </div>
         <div class="form-check">
-            <input class="form-check-input" type="radio" name="judge_choice" id="chair" value="chair">
-            <label class="form-check-label" for="chair">Chair</label>
+            <input class="form-check-input" type="radio" name="tournament" id="tourn_yes" value="yes">
+            <label class="form-check-label" for="tourn_yes">Yes</label>
+        </div>
+    </div>
+
+    <div class="mb-3">
+        <label class="form-label"><strong>How confident would you be chair judging a debate?</strong></label>
+        <div class="form-check">
+            <input class="form-check-input" type="radio" name="chair_confidence" id="chair_vc" value="very">
+            <label class="form-check-label" for="chair_vc">Very confident</label>
+        </div>
+        <div class="form-check">
+            <input class="form-check-input" type="radio" name="chair_confidence" id="chair_rc" value="rather">
+            <label class="form-check-label" for="chair_rc">Rather confident</label>
+        </div>
+        <div class="form-check">
+            <input class="form-check-input" type="radio" name="chair_confidence" id="chair_rnc" value="rather_not">
+            <label class="form-check-label" for="chair_rnc">Rather not confident</label>
+        </div>
+        <div class="form-check">
+            <input class="form-check-input" type="radio" name="chair_confidence" id="chair_nc" value="not">
+            <label class="form-check-label" for="chair_nc">Not confident</label>
+        </div>
+    </div>
+
+    <div class="mb-3">
+        <label class="form-label"><strong>How confident would you be judging a debate as a wing?</strong></label>
+        <div class="form-check">
+            <input class="form-check-input" type="radio" name="wing_confidence" id="wing_vc" value="very">
+            <label class="form-check-label" for="wing_vc">Very confident</label>
+        </div>
+        <div class="form-check">
+            <input class="form-check-input" type="radio" name="wing_confidence" id="wing_rc" value="rather">
+            <label class="form-check-label" for="wing_rc">Rather confident</label>
+        </div>
+        <div class="form-check">
+            <input class="form-check-input" type="radio" name="wing_confidence" id="wing_rnc" value="rather_not">
+            <label class="form-check-label" for="wing_rnc">Rather not confident</label>
+        </div>
+        <div class="form-check">
+            <input class="form-check-input" type="radio" name="wing_confidence" id="wing_nc" value="not">
+            <label class="form-check-label" for="wing_nc">Not confident</label>
         </div>
     </div>
 

--- a/app/templates/profile/view.html
+++ b/app/templates/profile/view.html
@@ -15,11 +15,16 @@
     <label class="form-label">Email</label>
     <input name="email" class="form-control" value="{{ current_user.email }}">
   </div>
+  <div class="mb-3">
+    <label class="form-label">Languages</label>
+    <input name="languages" class="form-control" value="{{ current_user.languages }}">
+  </div>
   <button type="submit" class="btn btn-primary">Update</button>
 </form>
 <hr>
 <p><strong>Debate Skill:</strong> {{ current_user.debate_skill or '—' }}</p>
 <p><strong>Judge Skill:</strong> {{ current_user.judge_skill or '—' }}</p>
+<p><strong>Languages:</strong> {{ current_user.languages or '—' }}</p>
 <p><strong>Debates Participated:</strong> {{ current_user.debate_count or 0 }}</p>
 <p><strong>BP Ranking:</strong> {{ '%.0f'|format(current_user.elo_rating) }} &plusmn; {{ '%.0f'|format(current_user.elo_sigma) }}</p>
 <p><strong>OPD Skill:</strong>

--- a/migrations/versions/f1f2f3f4f5f6_add_languages_to_user.py
+++ b/migrations/versions/f1f2f3f4f5f6_add_languages_to_user.py
@@ -1,0 +1,19 @@
+"""add languages column to user"""
+
+revision = 'f1f2f3f4f5f6'
+down_revision = '0d2e6c501f2d'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    with op.batch_alter_table('user', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('languages', sa.String(length=64), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table('user', schema=None) as batch_op:
+        batch_op.drop_column('languages')


### PR DESCRIPTION
## Summary
- store the languages a user debates in
- add database migration for the languages column
- extend the welcome survey with language choice and judging questions
- compute judging skill from chair/wing confidence
- show and edit languages in profile and admin views

## Testing
- `python -m py_compile app/auth/routes.py app/models.py app/profile/routes.py app/admin/routes.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853326be9808330b090a70f959182cc