### PR TITLE
Add elo ratings to dashboard participant view

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -297,7 +297,8 @@ def debate_assignments_json(debate_id):
             'role': s.role,
             'room': s.room,
             'user_id': s.user_id,
-            'name': f"{s.user.first_name} {s.user.last_name}"
+            'name': f"{s.user.first_name} {s.user.last_name}",
+            'elo': s.user.display_elo()
         } for s in slots
     ]
 

--- a/app/models.py
+++ b/app/models.py
@@ -121,6 +121,22 @@ class User(UserMixin, db.Model):
             .count()
         )
 
+    def display_elo(self):
+        """Return elo or estimated rating when sigma is high."""
+        sigma = getattr(self, "elo_sigma", None)
+        if sigma is not None and sigma <= 320:
+            return float(getattr(self, "elo_rating", 1000))
+
+        exp_map = {
+            "First Timer": 0,
+            "Beginner": 1,
+            "Intermediate": 2,
+            "Advanced": 3,
+            "Expert": 4,
+        }
+        exp = exp_map.get(getattr(self, "debate_skill", "First Timer"), 0)
+        return 1000 + exp * 50
+
     def __repr__(self):
         return f'<User {self.first_name} {self.last_name}>'
 

--- a/app/static/js/dashboard.js
+++ b/app/static/js/dashboard.js
@@ -89,6 +89,11 @@ function createBadge(slot) {
     em.textContent = ' (You)';
     span.appendChild(em);
   }
+  span.appendChild(document.createElement('br'));
+  const small = document.createElement('small');
+  small.classList.add('text-muted');
+  small.textContent = `Elo ${Math.round(slot.elo)}`;
+  span.appendChild(small);
   return span;
 }
 

--- a/app/templates/main/_role_badge.html
+++ b/app/templates/main/_role_badge.html
@@ -12,5 +12,6 @@
     <i class="bi bi-patch-question"></i>
   {% endif %}
   {{ slot.role }}<br>
-  {{ slot.user.first_name }} {{ slot.user.last_name }}{% if user.id == slot.user_id %} <em>(You)</em>{% endif %}
+  {{ slot.user.first_name }} {{ slot.user.last_name }}{% if user.id == slot.user_id %} <em>(You)</em>{% endif %}<br>
+  <small class="text-muted">Elo {{ '%.0f'|format(slot.user.display_elo()) }}</small>
 </span>


### PR DESCRIPTION
## Summary
- add `display_elo` helper on `User`
- expose elo rating in debate assignments JSON
- show elo rating in role badges
- display elo rating in dashboard graphics

## Testing
- `python -m py_compile app/models.py app/main/routes.py`

------
https://chatgpt.com/codex/tasks/task_e_685357f71fb48330b891aeea4374cd07