### PR TITLE
Add OPD points to dashboard view

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -298,7 +298,12 @@ def debate_assignments_json(debate_id):
             'room': s.room,
             'user_id': s.user_id,
             'name': f"{s.user.first_name} {s.user.last_name}",
-            'elo': s.user.display_elo()
+            'elo': s.user.display_elo(),
+            'opd_points': (
+                s.user.opd_skill
+                if s.user.opd_skill is not None
+                else s.user.opd_skill_level()
+            ),
         } for s in slots
     ]
 

--- a/app/static/js/dashboard.js
+++ b/app/static/js/dashboard.js
@@ -92,7 +92,11 @@ function createBadge(slot) {
   span.appendChild(document.createElement('br'));
   const small = document.createElement('small');
   small.classList.add('text-muted');
-  small.textContent = `Elo ${Math.round(slot.elo)}`;
+  let txt = `Elo ${Math.round(slot.elo)}`;
+  if (slot.opd_points !== null && slot.opd_points !== undefined) {
+    txt += ` | OPD ${slot.opd_points.toFixed(1)}`;
+  }
+  small.textContent = txt;
   span.appendChild(small);
   return span;
 }

--- a/app/templates/main/_role_badge.html
+++ b/app/templates/main/_role_badge.html
@@ -13,5 +13,9 @@
   {% endif %}
   {{ slot.role }}<br>
   {{ slot.user.first_name }} {{ slot.user.last_name }}{% if user.id == slot.user_id %} <em>(You)</em>{% endif %}<br>
-  <small class="text-muted">Elo {{ '%.0f'|format(slot.user.display_elo()) }}</small>
+  {% set opd_points = slot.user.opd_skill if slot.user.opd_skill is not none else slot.user.opd_skill_level() %}
+  <small class="text-muted">
+    Elo {{ '%.0f'|format(slot.user.display_elo()) }}
+    {% if opd_points is not none %}| OPD {{ '%.1f'|format(opd_points) }}{% endif %}
+  </small>
 </span>


### PR DESCRIPTION
## Summary
- include each user's OPD points in assignments JSON
- show OPD points beside Elo on role badges
- render OPD points in dashboard graphic view

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8 || true`

------
https://chatgpt.com/codex/tasks/task_e_68535a528f208330aeba023597f60b6a