### PR TITLE
Support external URLs using SERVER_NAME

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ These settings can be provided via environment variables or by modifying
 - **CORS_ALLOWED_ORIGINS** - origins allowed for CORS and SocketIO.
   Provide a comma-separated list (e.g. `https://example.com`). Default: `*`.
 - **PORT** - port used when running `python run.py`. Default: `5000`.
+- **SERVER_NAME** - domain name used for external URLs, e.g. in
+  confirmation emails. If unset, Flask uses the request host.
+- **PREFERRED_URL_SCHEME** - scheme used for URLs generated with
+  `url_for(..., _external=True)`. Default: `http`.
 
 ## 🚀 Production Deployment with uWSGI
 

--- a/config.py
+++ b/config.py
@@ -6,6 +6,8 @@ class Config:
     SQLALCHEMY_TRACK_MODIFICATIONS = os.getenv('SQLALCHEMY_TRACK_MODIFICATIONS', 'False').lower() in ('true', '1')
     CORS_ALLOWED_ORIGINS = os.getenv('CORS_ALLOWED_ORIGINS', '*')
     PORT = int(os.getenv('PORT', 5000))
+    SERVER_NAME = os.getenv('SERVER_NAME')
+    PREFERRED_URL_SCHEME = os.getenv('PREFERRED_URL_SCHEME', 'http')
 
     # Email configuration
     MAIL_SERVER = os.getenv('MAIL_SERVER', 'localhost')


### PR DESCRIPTION
## Summary
- allow Flask to build links with the actual site domain by using `SERVER_NAME` and `PREFERRED_URL_SCHEME`
- document the new config options

## Testing
- `python -m compileall -q app config.py run.py start.py`

------
https://chatgpt.com/codex/tasks/task_e_685371a767f48330a7b73eada5c70151