### PR TITLE
Add analytics page with debate score charts

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -37,12 +37,14 @@ def create_app(config_file=None):
     from .admin import admin_bp
     from .debate import debate_bp
     from .profile import profile_bp
+    from .analytics import analytics_bp
 
     app.register_blueprint(auth_bp)
     app.register_blueprint(main_bp)
     app.register_blueprint(admin_bp)
     app.register_blueprint(debate_bp)
     app.register_blueprint(profile_bp)
+    app.register_blueprint(analytics_bp)
     
     print(app.url_map)
     

--- a/app/analytics/__init__.py
+++ b/app/analytics/__init__.py
@@ -1,0 +1,5 @@
+from flask import Blueprint
+
+analytics_bp = Blueprint('analytics', __name__)
+
+from . import routes

--- a/app/analytics/routes.py
+++ b/app/analytics/routes.py
@@ -1,0 +1,51 @@
+from statistics import median
+from flask import render_template
+from flask_login import login_required
+
+from app.extensions import db
+from app.models import OpdResult, SpeakerSlot
+
+from . import analytics_bp
+
+
+@analytics_bp.route('/analytics')
+@login_required
+def analytics_dashboard():
+    # Collect all OPD scores
+    scores = [r.points for r in OpdResult.query.all() if r.points is not None]
+
+    # Gather points per debate and room
+    query = (
+        db.session.query(OpdResult.debate_id, SpeakerSlot.room, OpdResult.points)
+        .join(
+            SpeakerSlot,
+            (OpdResult.debate_id == SpeakerSlot.debate_id)
+            & (OpdResult.user_id == SpeakerSlot.user_id),
+        )
+    )
+    data = {}
+    for debate_id, room, points in query.all():
+        data.setdefault(room, {}).setdefault(debate_id, []).append(points)
+
+    # Calculate median for each debate/room
+    room_medians = {}
+    for room, debates in data.items():
+        room_medians[room] = {deb_id: median(vals) for deb_id, vals in debates.items()}
+
+    # Prepare labels and datasets for Chart.js
+    labels = sorted({deb_id for debates in data.values() for deb_id in debates.keys()})
+    datasets = []
+    for room in sorted(room_medians.keys()):
+        datasets.append(
+            {
+                'label': f'Room {room}',
+                'data': [room_medians[room].get(deb_id) for deb_id in labels],
+            }
+        )
+
+    return render_template(
+        'analytics/analytics.html',
+        hist_data=scores,
+        labels=labels,
+        datasets=datasets,
+    )

--- a/app/static/js/analytics.js
+++ b/app/static/js/analytics.js
@@ -1,0 +1,62 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const histCtx = document.getElementById('histogramChart').getContext('2d');
+
+  function createHistogram(data, min, max, bin) {
+    const labels = [];
+    const counts = [];
+    for (let start = min; start < max; start += bin) {
+      labels.push(`${start}-${start + bin}`);
+      counts.push(0);
+    }
+    data.forEach(val => {
+      const idx = Math.floor((val - min) / bin);
+      if (idx >= 0 && idx < counts.length) counts[idx]++;
+    });
+    return { labels, counts };
+  }
+
+  const hist = createHistogram(window.histData || [], 25, 65, 3);
+  new Chart(histCtx, {
+    type: 'bar',
+    data: {
+      labels: hist.labels,
+      datasets: [{
+        label: 'Averaged OPD Scores',
+        data: hist.counts,
+        backgroundColor: 'rgba(54, 162, 235, 0.5)',
+        borderColor: 'rgba(54, 162, 235, 1)',
+        borderWidth: 1
+      }]
+    },
+    options: {
+      scales: {
+        y: {
+          beginAtZero: true,
+          ticks: { stepSize: 1 }
+        }
+      }
+    }
+  });
+
+  const medianCtx = document.getElementById('medianChart').getContext('2d');
+  const datasets = (window.datasets || []).map(ds => ({
+    label: ds.label,
+    data: ds.data,
+    spanGaps: true
+  }));
+
+  new Chart(medianCtx, {
+    type: 'line',
+    data: {
+      labels: window.labels || [],
+      datasets: datasets
+    },
+    options: {
+      responsive: true,
+      interaction: { mode: 'index', intersect: false },
+      scales: {
+        y: { suggestedMin: 25, suggestedMax: 65 }
+      }
+    }
+  });
+});

--- a/app/templates/analytics/analytics.html
+++ b/app/templates/analytics/analytics.html
@@ -1,0 +1,27 @@
+{% extends "base.html" %}
+{% block title %}Analytics{% endblock %}
+
+{% block content %}
+<script>
+  window.histData = {{ hist_data | tojson }};
+  window.labels = {{ labels | tojson }};
+  window.datasets = {{ datasets | tojson }};
+</script>
+
+<h2 class="mb-4">Analytics</h2>
+
+<div class="mb-5">
+  <h4>Distribution of OPD Scores</h4>
+  <canvas id="histogramChart"></canvas>
+</div>
+
+<div>
+  <h4>Debate Quality by Median Score</h4>
+  <canvas id="medianChart"></canvas>
+</div>
+{% endblock %}
+
+{% block extra_js %}
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script src="{{ url_for('static', filename='js/analytics.js') }}"></script>
+{% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -30,6 +30,9 @@
         {% endif %}
         {% if current_user.is_authenticated %}
         <li class="nav-item">
+          <a class="nav-link" href="{{ url_for('analytics.analytics_dashboard') }}">Analytics</a>
+        </li>
+        <li class="nav-item">
           <a class="nav-link" href="{{ url_for('auth.logout') }}">Logout</a>
         </li>
         {% endif %}


### PR DESCRIPTION
## Summary
- Add analytics blueprint and route to visualize OPD score distribution and debate medians
- Create analytics dashboard with histogram and multi-room line chart
- Link new analytics page in navigation bar

## Testing
- `pytest`
- `python -m py_compile app/analytics/routes.py app/analytics/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_688e638602e0833082c9aa27793ac782