### PR TITLE
Add judge average scores chart

### DIFF
--- a/app/static/js/analytics.js
+++ b/app/static/js/analytics.js
@@ -59,4 +59,24 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     }
   });
+
+  const judgeCtx = document.getElementById('judgeAverages').getContext('2d');
+  new Chart(judgeCtx, {
+    type: 'bar',
+    data: {
+      labels: window.judgeLabels || [],
+      datasets: [{
+        label: 'Average Score',
+        data: window.judgeAverages || [],
+        backgroundColor: 'rgba(153, 102, 255, 0.5)',
+        borderColor: 'rgba(153, 102, 255, 1)',
+        borderWidth: 1
+      }]
+    },
+    options: {
+      scales: {
+        y: { beginAtZero: true }
+      }
+    }
+  });
 });

--- a/app/templates/analytics/analytics.html
+++ b/app/templates/analytics/analytics.html
@@ -2,11 +2,13 @@
 {% block title %}Analytics{% endblock %}
 
 {% block content %}
-<script>
-  window.histData = {{ hist_data | tojson }};
-  window.labels = {{ labels | tojson }};
-  window.datasets = {{ datasets | tojson }};
-</script>
+  <script>
+    window.histData = {{ hist_data | tojson }};
+    window.labels = {{ labels | tojson }};
+    window.datasets = {{ datasets | tojson }};
+    window.judgeLabels = {{ judge_labels | tojson }};
+    window.judgeAverages = {{ judge_averages | tojson }};
+  </script>
 
 <h2 class="mb-4">Analytics</h2>
 
@@ -15,11 +17,16 @@
   <canvas id="histogramChart"></canvas>
 </div>
 
-<div>
-  <h4>Debate Quality by Median Score</h4>
-  <canvas id="medianChart"></canvas>
-</div>
-{% endblock %}
+  <div>
+    <h4>Debate Quality by Median Score</h4>
+    <canvas id="medianChart"></canvas>
+  </div>
+
+  <div class="mt-5">
+    <h4>Average Score by Judge</h4>
+    <canvas id="judgeAverages"></canvas>
+  </div>
+  {% endblock %}
 
 {% block extra_js %}
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>


### PR DESCRIPTION
## Summary
- Aggregate judge scores and expose average ratings per judge
- Display judge averages chart in analytics dashboard
- Render new Chart.js bar chart using provided judge data

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e66c8f19083309afaf60fa384974f