### PR TITLE
Add privacy policy page and link

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -51,7 +51,7 @@ def create_app(config_file=None):
     @app.before_request
     def require_login():
         # These endpoints do NOT require login:
-        open_routes = ['auth.login', 'auth.register', 'auth.forgot_password', 'auth.reset_password', 'auth.confirm_email', 'static']
+        open_routes = ['auth.login', 'auth.register', 'auth.forgot_password', 'auth.reset_password', 'auth.confirm_email', 'main.privacy', 'static']
         # If the user is NOT authenticated and is not on a public page
         if (not current_user.is_authenticated
             and request.endpoint not in open_routes

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -11,6 +11,12 @@ from app.utils import compute_winning_topic
 
 from . import main_bp
 
+
+@main_bp.route('/privacy')
+def privacy():
+    """Public privacy policy page."""
+    return render_template('main/privacy.html')
+
 @main_bp.route('/')
 @login_required
 def dashboard():

--- a/app/templates/auth/login.html
+++ b/app/templates/auth/login.html
@@ -20,7 +20,8 @@
       </form>
       <div class="mt-3 text-center">
         <small><a href="{{ url_for('auth.forgot_password') }}">Forgot password?</a></small><br>
-        <small>Don't have an account? <a href="{{ url_for('auth.register') }}">Register here</a></small>
+        <small>Don't have an account? <a href="{{ url_for('auth.register') }}">Register here</a></small><br>
+        <small><a href="{{ url_for('main.privacy') }}">Privacy Policy</a></small>
       </div>
     </div>
   </div>

--- a/app/templates/main/privacy.html
+++ b/app/templates/main/privacy.html
@@ -1,0 +1,37 @@
+{% extends "base.html" %}
+{% block title %}Privacy Policy{% endblock %}
+
+{% block content %}
+<div class="container mt-4">
+  <h1>Privacy Policy</h1>
+  <p>We value your privacy. This policy explains what personal data we collect, why we collect it, and how it is used.</p>
+
+  <h2>Personal data collected</h2>
+  <ul>
+    <li><strong>Account registration:</strong> first name, last name, email address, and a password which is hashed before storage. These details are stored temporarily in a pending users table until you confirm your email.</li>
+    <li><strong>User profile:</strong> after confirmation, we keep the same identifying details along with administrative flags and metadata such as survey responses, language preferences, debate and judge skills, participation counts, and timestamps of last activity.</li>
+    <li><strong>Optional survey or profile updates:</strong> you may later provide or edit join-date choices, judging confidence, language lists, and other preferences through surveys and profile forms.</li>
+  </ul>
+
+  <h2>Purpose and legal basis</h2>
+  <p>We process this data to create and manage your account, facilitate debate assignments, communicate about the service, and improve the platform. The lawful bases include contract performance and our legitimate interest in operating a debating community.</p>
+
+  <h2>Retention</h2>
+  <p>Pending registrations are removed after confirmation or after a defined period. User data is kept while the account remains active and is deleted when no longer necessary or upon request.</p>
+
+  <h2>User rights</h2>
+  <p>You have the right to access, rectify, delete, or restrict processing of your data, as well as the rights to data portability and objection. To exercise these rights, contact the site administrators.</p>
+
+  <h2>Security measures</h2>
+  <p>We secure your data by hashing passwords, requiring email confirmation, and applying standard technical safeguards to protect our services.</p>
+
+  <h2>Data sharing</h2>
+  <p>We may share data with service providers who assist in delivering emails or hosting the application. These providers are bound by confidentiality and data protection obligations.</p>
+
+  <h2>Contact and complaints</h2>
+  <p>If you have questions or wish to exercise your rights, please contact the site administrators. You can also lodge a complaint with your local supervisory authority.</p>
+
+  <h2>Changes to this policy</h2>
+  <p>We may update this policy from time to time. Significant changes will be communicated on this page.</p>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Add public privacy policy page with GDPR information
- Link privacy policy from login screen for unauthenticated users
- Allow unauthenticated access to the privacy route

## Testing
- `pytest` (no tests run)
- `flake8` (fails: style violations across repository)

------
https://chatgpt.com/codex/tasks/task_e_688e677ce65883309d524a241de79bda