### PR TITLE
Add judging preference toggle on dashboard

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -94,6 +94,7 @@ def dashboard():
         is_judge_chair=is_judge_chair,
         second_voting_open=current_debate.second_voting_open if current_debate else False,
         winning_topic=winning_topic,
+        prefers_judging=current_user.prefer_judging,
     )
 
 

--- a/app/profile/routes.py
+++ b/app/profile/routes.py
@@ -1,4 +1,4 @@
-from flask import render_template, request, redirect, url_for, flash
+from flask import render_template, request, redirect, url_for, flash, jsonify
 from flask_login import login_required, current_user
 from app.extensions import db
 from app.models import OpdResult, Debate, EloLog, SpeakerSlot, BpRank, User
@@ -112,6 +112,16 @@ def view():
         )
 
     return render_template('profile/view.html', opd_result_count=opd_result_count, recent_debates=recent_debates)
+
+
+@profile_bp.route('/profile/prefer_judging', methods=['POST'])
+@login_required
+def prefer_judging():
+    data = request.get_json() or {}
+    pref = bool(data.get('prefer_judging'))
+    current_user.prefer_judging = pref
+    db.session.commit()
+    return jsonify({'prefer_judging': current_user.prefer_judging})
 
 
 @profile_bp.route('/profile/debate/<int:debate_id>/results')

--- a/app/static/js/dashboard.js
+++ b/app/static/js/dashboard.js
@@ -236,6 +236,17 @@ document.addEventListener('DOMContentLoaded', () => {
       judgeBtn.style.display = 'none';
     }
   }
+
+  const preferCheck = document.getElementById('preferJudging');
+  if (preferCheck) {
+    preferCheck.addEventListener('change', () => {
+      fetch('/profile/prefer_judging', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ prefer_judging: preferCheck.checked })
+      });
+    });
+  }
 });
 
 socket.on('vote_update', data => {

--- a/app/templates/main/dashboard.html
+++ b/app/templates/main/dashboard.html
@@ -56,6 +56,10 @@
         <div id="voteBoxContainer" class="card p-3 vote-box"{% if not current_debate or not current_debate.voting_open %} style="display:none"{% endif %}></div>
         <div id="graphicContainer" class="mt-3"{% if not current_debate or not current_debate.assignment_complete or not user_role %} style="display:none"{% endif %}></div>
       </div>
+      <div class="form-check mt-3">
+        <input class="form-check-input" type="checkbox" id="preferJudging" {% if prefers_judging %}checked{% endif %}>
+        <label class="form-check-label" for="preferJudging">Prefer judging</label>
+      </div>
       <a id="judgingButton"
          class="btn btn-warning mt-3{% if current_debate and not current_debate.active %} disabled{% endif %}"
          {% if current_debate and current_debate.active %}href="{{ url_for('debate.judging', debate_id=current_debate.id) }}"{% endif %}


### PR DESCRIPTION
## Summary
- add checkbox on dashboard to store users' judging preference
- expose judging preference flag in dashboard view and profile endpoint
- sync preference change through dashboard.js via fetch

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688e6e92eda48330aaa538106174b8c3