### PR TITLE
Reload judging panel when assignments ready

### DIFF
--- a/app/templates/debate/judging_bp.html
+++ b/app/templates/debate/judging_bp.html
@@ -33,4 +33,13 @@ function check() {
 document.querySelectorAll('.rank-input').forEach(i=>i.addEventListener('input', check));
 check();
 </script>
+<script>
+const socket = io();
+const currentDebateId = {{ debate.id }};
+socket.on('assignments_ready', data => {
+  if (data.debate_id === currentDebateId) {
+    window.location.reload();
+  }
+});
+</script>
 {% endblock %}

--- a/app/templates/debate/judging_opd.html
+++ b/app/templates/debate/judging_opd.html
@@ -53,4 +53,13 @@ function update() {
 update();
 document.querySelectorAll('.score-input').forEach(inp=>inp.addEventListener('input', update));
 </script>
+<script>
+const socket = io();
+const currentDebateId = {{ debate.id }};
+socket.on('assignments_ready', data => {
+  if (data.debate_id === currentDebateId) {
+    window.location.reload();
+  }
+});
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Reload BP judging page when the `assignments_ready` Socket.IO event matches the current debate
- Reload OPD judging page when the `assignments_ready` Socket.IO event matches the current debate

## Testing
- `pytest`
- `flake8` *(fails: many style errors across repository)*

------
https://chatgpt.com/codex/tasks/task_e_688e7a8ca6488330b1d0cef6cb80bae1