### PR TITLE
Enable late join on dashboard

### DIFF
--- a/app/templates/main/dashboard.html
+++ b/app/templates/main/dashboard.html
@@ -16,6 +16,7 @@
   window.currentUserId = {{ current_user.id }};
   window.userHasSlot = {{ 'true' if user_role else 'false' }};
   window.userIsJudgeChair = {{ 'true' if is_judge_chair else 'false' }};
+  window.userJudgeSkill = "{{ current_user.judge_skill or '' }}";
 </script>
 
 <div class="container my-4">
@@ -56,6 +57,9 @@
         <div id="voteBoxContainer" class="card p-3 vote-box"{% if not current_debate or not current_debate.voting_open %} style="display:none"{% endif %}></div>
         <div id="graphicContainer" class="mt-3"{% if not current_debate or not current_debate.assignment_complete or not user_role %} style="display:none"{% endif %}></div>
       </div>
+      {% if current_debate and current_debate.assignment_complete and not user_role %}
+      <button id="joinLaterBtn" class="btn btn-secondary mt-3" disabled>Join Debate</button>
+      {% endif %}
       <div class="form-check mt-3">
         <input class="form-check-input" type="checkbox" id="preferJudging" {% if prefers_judging %}checked{% endif %}>
         <label class="form-check-label" for="preferJudging">Prefer judging</label>


### PR DESCRIPTION
## Summary
- Add conditional Join Debate button to dashboard and expose judge skill
- Implement client logic to check slot availability and join via POST
- Refresh debate data when assignments change so roles update

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688e7a768dc48330874c0f0d3bb26091