### PR TITLE
Respect judging preference in join button

### DIFF
--- a/app/static/js/dashboard.js
+++ b/app/static/js/dashboard.js
@@ -238,6 +238,12 @@ function updateJoinLaterAvailability() {
         if (freeCount < maxFree) freeAvailable = true;
       });
       const canWing = ['Wing', 'Chair'].includes(window.userJudgeSkill);
+      const prefersJudge = window.preferJudging === true || window.preferJudging === 'true';
+      if (prefersJudge && freeAvailable && wingAvailable && canWing) {
+        btn.textContent = 'Join as Judge';
+      } else {
+        btn.textContent = 'Join Debate';
+      }
       if (freeAvailable || (wingAvailable && canWing)) {
         btn.disabled = false;
         btn.classList.remove('disabled', 'btn-secondary');

--- a/app/templates/main/dashboard.html
+++ b/app/templates/main/dashboard.html
@@ -17,6 +17,7 @@
   window.userHasSlot = {{ 'true' if user_role else 'false' }};
   window.userIsJudgeChair = {{ 'true' if is_judge_chair else 'false' }};
   window.userJudgeSkill = "{{ current_user.judge_skill or '' }}";
+  window.preferJudging = {{ 'true' if prefers_judging else 'false' }};
 </script>
 
 <div class="container my-4">

--- a/tests/dashboard_button_label.test.js
+++ b/tests/dashboard_button_label.test.js
@@ -1,0 +1,68 @@
+const fs = require('fs');
+const vm = require('vm');
+
+class ClassList {
+  constructor() { this.set = new Set(); }
+  add(...cls) { cls.forEach(c => this.set.add(c)); }
+  remove(...cls) { cls.forEach(c => this.set.delete(c)); }
+}
+
+function createButton() {
+  return {
+    id: 'joinLaterBtn',
+    disabled: true,
+    textContent: 'Join Debate',
+    style: { display: 'none' },
+    classList: new ClassList(),
+    addEventListener: () => {}
+  };
+}
+
+global.document = { addEventListener: () => {}, getElementById: () => null };
+global.window = {};
+global.io = () => ({ on: () => {} });
+global.fetch = () => Promise.resolve({ json: () => Promise.resolve({ assignments: [] }) });
+
+const code = fs.readFileSync('app/static/js/dashboard.js', 'utf8');
+vm.runInThisContext(code);
+
+async function runScenario(preferJudging, expected) {
+  const btn = createButton();
+  global.document = {
+    getElementById: id => id === 'joinLaterBtn' ? btn : null,
+    addEventListener: () => {}
+  };
+  global.window = {
+    currentDebateId: 1,
+    assignmentsComplete: true,
+    userHasSlot: false,
+    userJudgeSkill: 'Wing',
+    currentDebateStyle: 'OPD',
+    preferJudging: preferJudging
+  };
+  global.fetch = () => Promise.resolve({
+    json: () => Promise.resolve({
+      assignments: [
+        { role: 'Free-1', room: 1 },
+        { role: 'Judge-Wing', room: 1 }
+      ]
+    })
+  });
+  updateJoinLaterAvailability();
+  await new Promise(r => setTimeout(r, 0));
+  const text = btn.textContent.trim();
+  if (text !== expected) {
+    throw new Error(`expected "${expected}", got "${text}"`);
+  }
+}
+
+(async () => {
+  try {
+    await runScenario(true, 'Join as Judge');
+    await runScenario(false, 'Join Debate');
+    console.log('ok');
+  } catch (err) {
+    console.error(err);
+    process.exit(1);
+  }
+})();

--- a/tests/test_dashboard_ui.py
+++ b/tests/test_dashboard_ui.py
@@ -1,0 +1,7 @@
+import subprocess
+from pathlib import Path
+
+def test_join_button_label_changes():
+    script = Path(__file__).with_name('dashboard_button_label.test.js')
+    result = subprocess.run(['node', str(script)], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr + result.stdout


### PR DESCRIPTION
## Summary
- Expose `prefer_judging` flag to the dashboard client
- Show "Join as Judge" when judging is preferred and slots are available
- Add UI tests covering join button label behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e83e407188330afbbfd29d77f317c