### PR TITLE
test: update debate join roles

### DIFF
--- a/tests/test_debate_join.py
+++ b/tests/test_debate_join.py
@@ -31,15 +31,18 @@ def client(app):
 
 def login(client, user):
     with client.session_transaction() as sess:
+        sess.clear()
         sess['_user_id'] = str(user.id)
         sess['_fresh'] = True
 
 
 def create_user(idx, judge_skill='Cant judge'):
+    from uuid import uuid4
+
     user = User(
         first_name=f'User{idx}',
         last_name='Test',
-        email=f'user{idx}@example.com',
+        email=f'user{idx}_{uuid4()}@example.com',
         password='pw',
         judge_skill=judge_skill,
     )
@@ -65,19 +68,34 @@ def test_join_assigns_first_free_slot(client):
     ])
     db.session.commit()
 
+    judge_count_before = (
+        SpeakerSlot.query
+        .filter_by(debate_id=debate.id, room=1)
+        .filter(SpeakerSlot.role.like('Judge%'))
+        .count()
+    )
+
     login(client, joiner)
     resp = client.post(f'/debate/{debate.id}/join')
     data = resp.get_json()
     assert resp.status_code == 200
-    assert data['role'] == 'Free-2'
+    assert data['role'] == 'Judge-Wing'
     assert data['room'] == 1
 
     slot = SpeakerSlot.query.filter_by(debate_id=debate.id, user_id=joiner.id).first()
-    assert slot.role == 'Free-2'
+    assert slot.role == 'Judge-Wing'
     assert slot.room == 1
 
+    judge_count_after = (
+        SpeakerSlot.query
+        .filter_by(debate_id=debate.id, room=1)
+        .filter(SpeakerSlot.role.like('Judge%'))
+        .count()
+    )
+    assert judge_count_after == judge_count_before + 1
 
-def test_dynamic_debate_assigns_free_slot(client):
+
+def test_dynamic_debate_assigns_judge_slot(client):
     og = create_user(1)
     oo = create_user(2)
     cg = create_user(3)
@@ -104,9 +122,52 @@ def test_dynamic_debate_assigns_free_slot(client):
     resp = client.post(f'/debate/{debate.id}/join')
     data = resp.get_json()
     assert resp.status_code == 200
-    assert data['role'] == 'Free-1'
-    assert data['room'] == 2
+    assert data['role'] == 'Judge-Wing'
+    assert data['room'] == 1
 
     slot = SpeakerSlot.query.filter_by(debate_id=debate.id, user_id=joiner.id).first()
-    assert slot.role == 'Free-1'
+    assert slot.role == 'Judge-Wing'
+    assert slot.room == 1
+
+
+def test_dynamic_debate_assigns_free_slot_after_judges_full(client):
+    og = create_user(1)
+    oo = create_user(2)
+    cg = create_user(3)
+    co = create_user(4)
+    gov = create_user(5)
+    opp = create_user(6)
+    joiners = [create_user(i, judge_skill='Wing') for i in range(7, 12)]
+
+    debate = Debate(title='Dynamic Debate', style='Dynamic', active=True)
+    db.session.add(debate)
+    db.session.commit()
+
+    db.session.add_all([
+        SpeakerSlot(debate_id=debate.id, user_id=og.id, role='OG', room=1),
+        SpeakerSlot(debate_id=debate.id, user_id=oo.id, role='OO', room=1),
+        SpeakerSlot(debate_id=debate.id, user_id=cg.id, role='CG', room=1),
+        SpeakerSlot(debate_id=debate.id, user_id=co.id, role='CO', room=1),
+        SpeakerSlot(debate_id=debate.id, user_id=gov.id, role='Gov', room=2),
+        SpeakerSlot(debate_id=debate.id, user_id=opp.id, role='Opp', room=2),
+    ])
+    db.session.commit()
+
+    db.session.add_all([
+        SpeakerSlot(debate_id=debate.id, user_id=joiners[0].id, role='Judge-Wing', room=1),
+        SpeakerSlot(debate_id=debate.id, user_id=joiners[1].id, role='Judge-Wing', room=2),
+        SpeakerSlot(debate_id=debate.id, user_id=joiners[2].id, role='Judge-Wing', room=1),
+        SpeakerSlot(debate_id=debate.id, user_id=joiners[3].id, role='Judge-Wing', room=2),
+    ])
+    db.session.commit()
+
+    login(client, joiners[4])
+    resp = client.post(f'/debate/{debate.id}/join')
+    data = resp.get_json()
+    assert resp.status_code == 200
+    assert data['role'].startswith('Free-')
+    assert data['room'] == 2
+
+    slot = SpeakerSlot.query.filter_by(debate_id=debate.id, user_id=joiners[4].id).first()
+    assert slot.role.startswith('Free-')
     assert slot.room == 2


### PR DESCRIPTION
## Summary
- prioritize judge assignment over free slots during debate joins
- update tests for judge-first behavior and add coverage for filled-judge scenarios

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e83c14ad08330bcabd6ae10a60cf5