### PR TITLE
feat: modern responsive UI theme

### DIFF
--- a/app/static/css/theme.css
+++ b/app/static/css/theme.css
@@ -1,0 +1,106 @@
+:root{
+  --blue-900:#0D3B66; --blue-800:#144C7D; --blue-100:#E8F1FA;
+  --gray-25:#FCFCFD; --gray-50:#F7F7F9; --gray-100:#F0F2F5; --gray-200:#E5E7EB;
+  --gray-300:#D1D5DB; --gray-400:#9CA3AF; --gray-600:#4B5563; --gray-800:#1F2937;
+  --white:#fff; --radius:12px;
+  --shadow-sm:0 1px 3px rgba(0,0,0,.08);
+  --shadow-md:0 8px 24px rgba(13,59,102,.12);
+}
+
+body{
+  background:var(--gray-50);
+  color:var(--gray-800);
+  line-height:1.5;
+}
+
+.skip-link{
+  position:absolute;
+  top:-40px;
+  left:0;
+  background:var(--blue-900);
+  color:var(--white);
+  padding:.5rem 1rem;
+  z-index:1000;
+}
+.skip-link:focus{top:0;}
+
+.navbar{
+  background:var(--blue-900);
+  color:var(--white);
+  position:sticky;
+  top:0;
+  z-index:999;
+  box-shadow:var(--shadow-sm);
+}
+.navbar .navbar-brand,
+.navbar .nav-link{color:var(--white);}
+.navbar .nav-link.active,
+.navbar .nav-link:focus,
+.navbar .nav-link:hover{color:var(--blue-100);text-decoration:underline;}
+
+.container{max-width:1200px;margin:0 auto;padding:1rem;}
+.grid{display:grid;grid-template-columns:repeat(12,1fr);gap:1rem;}
+@media(max-width:768px){.grid{grid-template-columns:repeat(6,1fr);}}
+@media(max-width:576px){.grid{grid-template-columns:1fr;}}
+.col-span-6{grid-column:span 6;}
+.col-span-12{grid-column:span 12;}
+
+.card{background:var(--white);border:1px solid var(--gray-200);border-radius:var(--radius);box-shadow:var(--shadow-sm);} 
+.card-header{padding:.75rem 1rem;border-bottom:1px solid var(--gray-200);background:var(--gray-25);border-top-left-radius:var(--radius);border-top-right-radius:var(--radius);} 
+.card-body{padding:1rem;} 
+.card-footer{padding:.75rem 1rem;border-top:1px solid var(--gray-200);background:var(--gray-25);border-bottom-left-radius:var(--radius);border-bottom-right-radius:var(--radius);} 
+
+.btn{border-radius:var(--radius);padding:.5rem 1rem;border:1px solid transparent;transition:background .2s, color .2s, box-shadow .2s;}
+.btn:focus{box-shadow:0 0 0 3px rgba(13,59,102,.3);} 
+.btn-primary{background:var(--blue-800);border-color:var(--blue-800);color:var(--white);} 
+.btn-primary:hover{background:var(--blue-900);border-color:var(--blue-900);} 
+.btn-secondary{background:var(--gray-600);border-color:var(--gray-600);color:var(--white);} 
+.btn-secondary:hover{background:var(--gray-800);border-color:var(--gray-800);} 
+.btn-outline{background:transparent;border-color:var(--blue-800);color:var(--blue-800);} 
+.btn-outline:hover{background:var(--blue-100);} 
+.btn-warning{background:#EAB308;border-color:#EAB308;color:var(--gray-800);} 
+.btn-warning:hover{background:#CA8A04;border-color:#CA8A04;color:var(--gray-25);} 
+.btn:disabled,.btn.disabled{opacity:.6;pointer-events:none;}
+
+.badge{border-radius:999px;padding:.25em .5em;font-size:.75rem;font-weight:500;}
+.badge-blue{background:var(--blue-800);color:var(--white);} 
+.badge-gray{background:var(--gray-300);color:var(--gray-800);} 
+.badge-green{background:#16A34A;color:var(--white);} 
+.badge-amber{background:#F59E0B;color:var(--gray-800);} 
+
+.tabs{display:flex;gap:.25rem;border-bottom:1px solid var(--gray-200);} 
+.tabs .tab{padding:.5rem 1rem;background:transparent;border:none;border-bottom:3px solid transparent;color:var(--gray-600);cursor:pointer;} 
+.tabs .tab:hover{color:var(--blue-800);} 
+.tabs .tab:focus{outline:none;box-shadow:0 0 0 2px var(--blue-100);} 
+.tabs .tab.active{border-bottom-color:var(--blue-800);color:var(--blue-800);font-weight:600;} 
+
+.table-wrap{overflow-x:auto;} 
+.table{min-width:600px;} 
+.table thead{position:sticky;top:0;background:var(--blue-900);color:var(--white);} 
+.table tbody tr:nth-child(odd){background:var(--gray-50);} 
+.table tbody tr:hover{background:var(--gray-100);} 
+
+.field{margin-bottom:1rem;} 
+.field .label{display:block;margin-bottom:.25rem;font-weight:500;} 
+.field .input,.field .select{width:100%;padding:.5rem .75rem;border:1px solid var(--gray-300);border-radius:var(--radius);background:var(--white);} 
+.field .input:focus,.field .select:focus{outline:none;border-color:var(--blue-800);box-shadow:0 0 0 3px var(--blue-100);} 
+
+.progress{background:var(--gray-200);border-radius:var(--radius);overflow:hidden;}
+.progress-bar{background:var(--blue-800);color:var(--white);transition:width .4s ease;}
+
+.rooms{display:flex;flex-wrap:wrap;gap:1rem;}
+.rooms .room{border:1px solid var(--gray-200);padding:1rem;border-radius:var(--radius);flex:1 1 200px;box-shadow:var(--shadow-sm);} 
+.rooms .role.gov{color:#16A34A;} 
+.rooms .role.opp{color:#DC2626;} 
+
+.focus-visible{outline:2px solid var(--blue-800);outline-offset:2px;}
+
+.table thead th{white-space:nowrap;}
+
+.bar-stub{height:200px;background:repeating-linear-gradient(90deg,var(--blue-100),var(--blue-100)10px,transparent 10px,transparent 20px);}
+.line-stub{width:100%;height:40px;}
+
+@media(max-width:576px){
+  .navbar .navbar-brand{font-size:1.25rem;}
+  .progress{height:1rem;}
+}

--- a/app/templates/admin/users.html
+++ b/app/templates/admin/users.html
@@ -2,7 +2,8 @@
 {% block title %}User Management{% endblock %}
 {% block content %}
 <h2>User Management</h2>
-<table class="table table-bordered table-striped">
+<div class="table-wrap mb-3">
+<table class="table">
   <thead>
     <tr>
       <th>ID</th>
@@ -26,7 +27,7 @@
       <td>{{ user.id }}</td>
       <td>{{ user.first_name }} {{ user.last_name }}</td>
       <td>{{ user.email }}</td>
-      <td>{% if user.is_admin %}<span class="badge bg-success">Yes</span>{% else %}No{% endif %}</td>
+      <td>{% if user.is_admin %}<span class="badge badge-green">Yes</span>{% else %}No{% endif %}</td>
       <td>{{ user.date_joined_choice or "—" }}</td>
       <td>{{ user.judge_choice or "—" }}</td>
       <td>{{ user.debate_skill or "—" }}</td>
@@ -35,27 +36,19 @@
       <td>{{ '%.1f'|format(user.opd_skill) if user.opd_skill is not none else "—" }}</td>
       <td>{{ '%.0f'|format(user.elo_rating) if user.elo_rating is not none else "—" }}</td>
       <td>{{ '%.0f'|format(user.elo_sigma) if user.elo_sigma is not none else "—" }}</td>
-		<td class="py-2">
-		  <!-- Flex row with a little spacing between children -->
-		  <div class="d-flex gap-1">
-			<form action="{{ url_for('admin.toggle_user_admin', user_id=user.id) }}"
-				  method="post"
-				  class="m-0">           <!-- remove default form margins -->
-			  <button type="submit" class="btn btn-sm btn-warning">
-				{% if user.is_admin %}Revoke Admin{% else %}Make Admin{% endif %}
-			  </button>
-			</form>
-
-			<a href="{{ url_for('admin.edit_user', user_id=user.id) }}"
-			   class="btn btn-sm btn-primary d-flex align-items-center justify-content-center">
-			   Edit
-			</a>
-		  </div>
-		</td>
+      <td class="py-2">
+        <div class="d-flex gap-1">
+          <form action="{{ url_for('admin.toggle_user_admin', user_id=user.id) }}" method="post" class="m-0">
+            <button type="submit" class="btn btn-sm btn-warning">{% if user.is_admin %}Revoke Admin{% else %}Make Admin{% endif %}</button>
+          </form>
+          <a href="{{ url_for('admin.edit_user', user_id=user.id) }}" class="btn btn-sm btn-primary d-flex align-items-center justify-content-center">Edit</a>
+        </div>
+      </td>
     </tr>
     {% endfor %}
   </tbody>
 </table>
+</div>
 <a href="{{ url_for('admin.manage_pending_users') }}" class="btn btn-warning">View Pending Registrations</a>
-<a href="{{ url_for('admin.admin_dashboard') }}" class="btn btn-link">Back to Admin Dashboard</a>
+<a href="{{ url_for('admin.admin_dashboard') }}" class="btn btn-outline">Back to Admin Dashboard</a>
 {% endblock %}

--- a/app/templates/analytics/analytics.html
+++ b/app/templates/analytics/analytics.html
@@ -10,14 +10,20 @@
 
 <h2 class="mb-4">Analytics</h2>
 
-<div class="mb-5">
-  <h4>Distribution of OPD Scores</h4>
-  <canvas id="histogramChart"></canvas>
+<div class="card mb-4">
+  <div class="card-header">Distribution of OPD Scores</div>
+  <div class="card-body">
+    <canvas id="histogramChart"></canvas>
+    <div class="bar-stub" aria-hidden="true"></div>
+  </div>
 </div>
 
-<div>
-  <h4>Debate Quality by Median Score</h4>
-  <canvas id="medianChart"></canvas>
+<div class="card">
+  <div class="card-header">Debate Quality by Median Score</div>
+  <div class="card-body">
+    <canvas id="medianChart"></canvas>
+    <svg class="line-stub" aria-hidden="true" viewBox="0 0 100 20"><line x1="0" y1="10" x2="100" y2="10" stroke="var(--gray-300)" stroke-width="2" stroke-dasharray="4 4"/></svg>
+  </div>
 </div>
 {% endblock %}
 

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -7,13 +7,15 @@
 
     <!-- Global CSS -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/theme.css') }}">
 
     <!-- Page-specific CSS -->
     {% block extra_head %}{% endblock %}
 </head>
 <body>
-<nav class="navbar navbar-expand-lg navbar-light bg-light mb-4">
-  <div class="container-fluid">
+<a href="#maincontent" class="skip-link">Skip to content</a>
+<nav class="navbar navbar-expand-lg">
+  <div class="container">
     <a class="navbar-brand" href="{{ url_for('main.dashboard') }}">DebateHub</a>
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
@@ -41,7 +43,7 @@
   </div>
 </nav>
 
-<div class="container my-5">
+<main id="maincontent" class="container my-5">
     {% with messages = get_flashed_messages(with_categories=true) %}
       {% if messages %}
         {% for category, message in messages %}
@@ -54,7 +56,7 @@
     {% endwith %}
 
     {% block content %}{% endblock %}
-</div>
+</main>
 
 <!-- Global JS -->
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>

--- a/app/templates/main/dashboard.html
+++ b/app/templates/main/dashboard.html
@@ -20,119 +20,110 @@
   window.preferJudging = {{ 'true' if prefers_judging else 'false' }};
 </script>
 
-<div class="container my-4">
+<div class="mb-4 text-center">
+  <h2>Welcome, {{ current_user.first_name }} {{ current_user.last_name }}!</h2>
+</div>
 
-  <!-- Welcome Banner -->
-  <div class="mb-4 text-center">
-    <h2>Welcome, {{ current_user.first_name }} {{ current_user.last_name }}!</h2>
-  </div>
-
-  <!-- Current Debate Card -->
-  <div class="card shadow current-debate mb-4">
+<div class="grid mb-4">
+  <div class="card text-center">
     <div class="card-body">
-      <h4 class="card-title d-flex justify-content-between align-items-center">
-        {{ current_debate.title or 'No debate right now' }}
-        {% if current_debate.style %}
-          <span class="badge bg-info">{{ current_debate.style }}</span>
-        {% endif %}
-      </h4>
-      <div id="voteProgress" class="progress my-2" style="height: 1.25rem;{% if not current_debate %} display:none;{% endif %}">
-        <div class="progress-bar bg-success"
-             style="width: {{ vote_percent or 0 }}%;"
-             aria-valuenow="{{ vote_percent or 0 }}" aria-valuemin="0" aria-valuemax="100">
-          {{ votes_cast or 0 }}/{{ votes_total or 0 }}
-        </div>
-      </div>
-      <div id="voteInfo" class="d-flex justify-content-between align-items-center mb-2"{% if not current_debate %} style="display:none"{% endif %}>
-        <small class="text-muted">{{ votes_cast or 0 }}/{{ votes_total or 0 }} have voted</small>
-        <small class="text-muted">{{ vote_percent or 0 }}%</small>
-      </div>
-      <p id="winningFactsheet" class="mt-2 small text-muted factsheet-content"{% if not winning_topic or not winning_topic.factsheet %} style="display:none"{% endif %}>
-        {% if winning_topic and winning_topic.factsheet %}{{ winning_topic.factsheet }}{% endif %}
-      </p>
-      <p id="winningTopic" class="mt-2 fw-bold text-success"{% if not winning_topic %} style="display:none"{% endif %}>
-        {% if winning_topic %}Winning topic: {{ winning_topic.text }}{% endif %}
-      </p>
-      <p id="userRoleText" class="mt-2 fw-bold text-primary"{% if not user_role %} style="display:none"{% endif %}>You are {{ user_role }}</p>
-      <div class="mt-3">
-        <div id="voteBoxContainer" class="card p-3 vote-box"{% if not current_debate or not current_debate.voting_open %} style="display:none"{% endif %}></div>
-        <div id="graphicContainer" class="mt-3"{% if not current_debate or not current_debate.assignment_complete or not user_role %} style="display:none"{% endif %}></div>
-      </div>
-      {% if current_debate and current_debate.assignment_complete and not user_role %}
-      <button id="joinLaterBtn" class="btn btn-secondary mt-3" disabled>Join Debate</button>
-      {% endif %}
-      <div class="form-check mt-3">
-        <input class="form-check-input" type="checkbox" id="preferJudging" {% if prefers_judging %}checked{% endif %}>
-        <label class="form-check-label" for="preferJudging">Prefer judging</label>
-      </div>
-      <a id="judgingButton"
-         class="btn btn-warning mt-3{% if current_debate and not current_debate.active %} disabled{% endif %}"
-         {% if current_debate and current_debate.active %}href="{{ url_for('debate.judging', debate_id=current_debate.id) }}"{% endif %}
-         {% if not current_debate or not current_debate.assignment_complete or not is_judge_chair %}style="display:none"{% elif current_debate and not current_debate.active %} aria-disabled="true"{% endif %}>Judging</a>
-      <p id="noDebateMessage" class="text-muted"{% if current_debate %} style="display:none"{% endif %}>No active debate at the moment.</p>
+      <div class="text-muted small">Active</div>
+      <div class="fs-4">{{ active_debates|length }}</div>
     </div>
   </div>
+  <div class="card text-center">
+    <div class="card-body">
+      <div class="text-muted small">Upcoming</div>
+      <div class="fs-4">{{ upcoming_debates|length }}</div>
+    </div>
+  </div>
+  <div class="card text-center">
+    <div class="card-body">
+      <div class="text-muted small">Past</div>
+      <div class="fs-4">{{ past_debates|length }}</div>
+    </div>
+  </div>
+</div>
 
-  <!-- Section Tabs -->
-  <ul class="nav nav-pills mb-3 justify-content-center" id="debateTabs" role="tablist">
-    <li class="nav-item" role="presentation">
-      <button class="nav-link active" id="active-tab" data-bs-toggle="pill"
-        data-bs-target="#active" type="button" role="tab">Active</button>
-    </li>
-    <li class="nav-item" role="presentation">
-      <button class="nav-link" id="past-tab" data-bs-toggle="pill"
-        data-bs-target="#past" type="button" role="tab">Past</button>
-    </li>
-    <li class="nav-item" role="presentation">
-      <button class="nav-link" id="upcoming-tab" data-bs-toggle="pill"
-        data-bs-target="#upcoming" type="button" role="tab">Upcoming</button>
-    </li>
-  </ul>
+<div class="card current-debate mb-4">
+  <div class="card-header d-flex justify-content-between align-items-center">
+    <span>{{ current_debate.title or 'No debate right now' }}</span>
+    {% if current_debate.style %}
+      <span class="badge badge-blue">{{ current_debate.style }}</span>
+    {% endif %}
+  </div>
+  <div class="card-body">
+    <div id="voteProgress" class="progress my-2" style="{% if not current_debate %}display:none;{% endif %}">
+      <div class="progress-bar" style="width: {{ vote_percent or 0 }}%;" aria-valuenow="{{ vote_percent or 0 }}" aria-valuemin="0" aria-valuemax="100">{{ votes_cast or 0 }}/{{ votes_total or 0 }}</div>
+    </div>
+    <div id="voteInfo" class="d-flex justify-content-between align-items-center mb-2"{% if not current_debate %} style="display:none"{% endif %}>
+      <small class="text-muted">{{ votes_cast or 0 }}/{{ votes_total or 0 }} have voted</small>
+      <small class="text-muted">{{ vote_percent or 0 }}%</small>
+    </div>
+    <p id="winningFactsheet" class="mt-2 small text-muted factsheet-content"{% if not winning_topic or not winning_topic.factsheet %} style="display:none"{% endif %}>{% if winning_topic and winning_topic.factsheet %}{{ winning_topic.factsheet }}{% endif %}</p>
+    <p id="winningTopic" class="mt-2 fw-bold text-success"{% if not winning_topic %} style="display:none"{% endif %}>{% if winning_topic %}Winning topic: {{ winning_topic.text }}{% endif %}</p>
+    <p id="userRoleText" class="mt-2 fw-bold text-primary"{% if not user_role %} style="display:none"{% endif %}>You are {{ user_role }}</p>
+    <div class="mt-3">
+      <div id="voteBoxContainer" class="card p-3 vote-box"{% if not current_debate or not current_debate.voting_open %} style="display:none"{% endif %}></div>
+      <div id="graphicContainer" class="mt-3"{% if not current_debate or not current_debate.assignment_complete or not user_role %} style="display:none"{% endif %}></div>
+    </div>
+    {% if current_debate and current_debate.assignment_complete and not user_role %}
+    <button id="joinLaterBtn" class="btn btn-secondary mt-3" disabled>Join Debate</button>
+    {% endif %}
+    <div class="form-check mt-3">
+      <input class="form-check-input" type="checkbox" id="preferJudging" {% if prefers_judging %}checked{% endif %}>
+      <label class="form-check-label" for="preferJudging">Prefer judging</label>
+    </div>
+    <a id="judgingButton" class="btn btn-warning mt-3{% if current_debate and not current_debate.active %} disabled{% endif %}" {% if current_debate and current_debate.active %}href="{{ url_for('debate.judging', debate_id=current_debate.id) }}"{% endif %} {% if not current_debate or not current_debate.assignment_complete or not is_judge_chair %}style="display:none"{% elif current_debate and not current_debate.active %} aria-disabled="true"{% endif %}>Judging</a>
+    <p id="noDebateMessage" class="text-muted"{% if current_debate %} style="display:none"{% endif %}>No active debate at the moment.</p>
+  </div>
+</div>
 
-  <!-- Debate Cards (Dummy values) -->
-  <div class="tab-content">
-    <div class="tab-pane fade show active" id="active" role="tabpanel">
-      {% for d in active_debates %}
-        <div class="card debate-card mb-3">
-          <div class="card-body">
-            <h6 class="card-title">{{ d.title }}</h6>
-            <span class="badge bg-info">{{ d.style }}</span>
-            <a href="{{ url_for('main.debate_view', debate_id=d.id) }}"
-              class="stretched-link"></a>
-          </div>
+<div class="tabs justify-content-center mb-3" id="debateTabs" role="tablist">
+  <button class="tab active" id="active-tab" data-bs-toggle="pill" data-bs-target="#active" type="button" role="tab">Active</button>
+  <button class="tab" id="past-tab" data-bs-toggle="pill" data-bs-target="#past" type="button" role="tab">Past</button>
+  <button class="tab" id="upcoming-tab" data-bs-toggle="pill" data-bs-target="#upcoming" type="button" role="tab">Upcoming</button>
+</div>
+
+<div class="tab-content">
+  <div class="tab-pane fade show active" id="active" role="tabpanel">
+    {% for d in active_debates %}
+      <div class="card debate-card mb-3">
+        <div class="card-body">
+          <h6 class="card-title">{{ d.title }}</h6>
+          <span class="badge badge-blue">{{ d.style }}</span>
+          <a href="{{ url_for('main.debate_view', debate_id=d.id) }}" class="stretched-link"></a>
         </div>
-      {% else %}
-        <div class="text-center text-muted my-4">No other active debates.</div>
-      {% endfor %}
-    </div>
-    <div class="tab-pane fade" id="past" role="tabpanel">
-      {% for d in past_debates %}
-        <div class="card debate-card mb-3">
-          <div class="card-body">
-            <h6 class="card-title">{{ d.title }}</h6>
-            <span class="badge bg-secondary">{{ d.style }}</span>
-            <a href="{{ url_for('main.debate_view', debate_id=d.id) }}"
-              class="stretched-link"></a>
-          </div>
+      </div>
+    {% else %}
+      <div class="text-center text-muted my-4">No other active debates.</div>
+    {% endfor %}
+  </div>
+  <div class="tab-pane fade" id="past" role="tabpanel">
+    {% for d in past_debates %}
+      <div class="card debate-card mb-3">
+        <div class="card-body">
+          <h6 class="card-title">{{ d.title }}</h6>
+          <span class="badge badge-gray">{{ d.style }}</span>
+          <a href="{{ url_for('main.debate_view', debate_id=d.id) }}" class="stretched-link"></a>
         </div>
-      {% else %}
-        <div class="text-center text-muted my-4">No past debates.</div>
-      {% endfor %}
-    </div>
-    <div class="tab-pane fade" id="upcoming" role="tabpanel">
-      {% for d in upcoming_debates %}
-        <div class="card debate-card mb-3">
-          <div class="card-body">
-            <h6 class="card-title">{{ d.title }}</h6>
-            <span class="badge bg-warning text-dark">{{ d.style }}</span>
-            <a href="{{ url_for('main.debate_view', debate_id=d.id) }}"
-              class="stretched-link"></a>
-          </div>
+      </div>
+    {% else %}
+      <div class="text-center text-muted my-4">No past debates.</div>
+    {% endfor %}
+  </div>
+  <div class="tab-pane fade" id="upcoming" role="tabpanel">
+    {% for d in upcoming_debates %}
+      <div class="card debate-card mb-3">
+        <div class="card-body">
+          <h6 class="card-title">{{ d.title }}</h6>
+          <span class="badge badge-amber">{{ d.style }}</span>
+          <a href="{{ url_for('main.debate_view', debate_id=d.id) }}" class="stretched-link"></a>
         </div>
-      {% else %}
-        <div class="text-center text-muted my-4">No upcoming debates.</div>
-      {% endfor %}
-    </div>
+      </div>
+    {% else %}
+      <div class="text-center text-muted my-4">No upcoming debates.</div>
+    {% endfor %}
   </div>
 </div>
 {% endblock %}

--- a/app/templates/main/debate.html
+++ b/app/templates/main/debate.html
@@ -2,46 +2,52 @@
 {% block title %}{{ debate.title }}{% endblock %}
 
 {% block content %}
-<h2>{{ debate.title }} ({{ debate.style }})</h2>
-
-{% if debate.voting_open %}
-  <form method="post">
-    <ul>
-      {% for topic in debate.topics %}
-        <li>
-          {{ topic.text }}
-          {% if topic.factsheet %}
-            <details class="d-inline-block ms-2">
-              <summary>Factsheet</summary>
-              <div class="factsheet-content">{{ topic.factsheet }}</div>
-            </details>
-          {% endif %}
-          {% if topic.id in user_votes %}
-            <strong>— You voted</strong>
-          {% elif votes_left > 0 %}
-            <button name="topic_id" value="{{ topic.id }}" class="btn btn-primary btn-sm">Vote</button>
-          {% endif %}
-        </li>
-      {% endfor %}
-    </ul>
-    <p>You have {{ votes_left }} vote{{ 's' if votes_left != 1 else '' }} left for this debate.</p>
-  </form>
-{% else %}
-  <h4 class="mt-4">Results</h4>
-  <ul>
-    {% for topic in debate.topics %}
-      <li>
-        {{ topic.text }} — <strong>{{ topic.votes|length }} vote{{ '' if topic.votes|length == 1 else 's' }}</strong>
-        {% if topic.votes|length == debate.topics | map(attribute='votes') | map('length') | max %}
-          <span class="badge bg-success">Winner</span>
-        {% endif %}
-      </li>
-    {% endfor %}
-  </ul>
-  <a href="{{ url_for('main.dashboard') }}" class="btn btn-link">Back to dashboard</a>
-{% endif %}
+<div class="card mb-4">
+  <div class="card-header d-flex justify-content-between align-items-center">
+    <h2 class="h5 m-0">{{ debate.title }}</h2>
+    <span class="badge badge-blue">{{ debate.style }}</span>
+  </div>
+  <div class="card-body">
+    {% if debate.voting_open %}
+      <form method="post">
+        <ul class="list-unstyled">
+          {% for topic in debate.topics %}
+            <li class="mb-2">
+              {{ topic.text }}
+              {% if topic.factsheet %}
+                <details class="d-inline-block ms-2">
+                  <summary>Factsheet</summary>
+                  <div class="factsheet-content">{{ topic.factsheet }}</div>
+                </details>
+              {% endif %}
+              {% if topic.id in user_votes %}
+                <strong>— You voted</strong>
+              {% elif votes_left > 0 %}
+                <button name="topic_id" value="{{ topic.id }}" class="btn btn-primary btn-sm">Vote</button>
+              {% endif %}
+            </li>
+          {% endfor %}
+        </ul>
+        <p>You have {{ votes_left }} vote{{ 's' if votes_left != 1 else '' }} left for this debate.</p>
+      </form>
+    {% else %}
+      <h4 class="mb-3">Results</h4>
+      <ul class="list-unstyled">
+        {% for topic in debate.topics %}
+          <li class="mb-1">
+            {{ topic.text }} — <strong>{{ topic.votes|length }} vote{{ '' if topic.votes|length == 1 else 's' }}</strong>
+            {% if topic.votes|length == debate.topics | map(attribute='votes') | map('length') | max %}
+              <span class="badge badge-green">Winner</span>
+            {% endif %}
+          </li>
+        {% endfor %}
+      </ul>
+      <a href="{{ url_for('main.dashboard') }}" class="btn btn-outline mt-3">Back to dashboard</a>
+    {% endif %}
+  </div>
+</div>
 {% if current_user.is_admin or slots_by_room %}
-  <a href="{{ url_for('main.debate_assignments', debate_id=debate.id) }}" class="btn btn-info mt-3">View Speaker Assignments</a>
+  <a href="{{ url_for('main.debate_assignments', debate_id=debate.id) }}" class="btn btn-primary mt-3">View Speaker Assignments</a>
 {% endif %}
 {% if debate.assignment_complete %}
     <a href="{{ url_for('main.debate_graphic', debate_id=debate.id) }}" class="btn btn-primary mt-3">

--- a/app/templates/profile/view.html
+++ b/app/templates/profile/view.html
@@ -1,32 +1,40 @@
 {% extends "base.html" %}
 {% block title %}Profile{% endblock %}
 {% block content %}
-<h2>Profile</h2>
-<form method="post" class="mb-3">
-  <div class="mb-3">
-    <label class="form-label">First Name</label>
-    <input name="first_name" class="form-control" value="{{ current_user.first_name }}">
+<div class="card profile-card mb-4">
+  <div class="card-header">Profile</div>
+  <div class="card-body">
+    <form method="post" class="grid">
+      <div class="field col-span-6">
+        <label class="label">First Name</label>
+        <input name="first_name" class="input" value="{{ current_user.first_name }}">
+      </div>
+      <div class="field col-span-6">
+        <label class="label">Last Name</label>
+        <input name="last_name" class="input" value="{{ current_user.last_name }}">
+      </div>
+      <div class="field col-span-6">
+        <label class="label">Email</label>
+        <input name="email" class="input" value="{{ current_user.email }}">
+      </div>
+      <div class="field col-span-6">
+        <label class="label">Languages</label>
+        <input name="languages" class="input" value="{{ current_user.languages }}">
+      </div>
+      <div class="col-span-12">
+        <button type="submit" class="btn btn-primary">Update</button>
+      </div>
+    </form>
   </div>
-  <div class="mb-3">
-    <label class="form-label">Last Name</label>
-    <input name="last_name" class="form-control" value="{{ current_user.last_name }}">
-  </div>
-  <div class="mb-3">
-    <label class="form-label">Email</label>
-    <input name="email" class="form-control" value="{{ current_user.email }}">
-  </div>
-  <div class="mb-3">
-    <label class="form-label">Languages</label>
-    <input name="languages" class="form-control" value="{{ current_user.languages }}">
-  </div>
-  <button type="submit" class="btn btn-primary">Update</button>
-</form>
-<hr>
-<!-- <p><strong>Debate Skill:</strong> {{ current_user.debate_skill or '—' }}</p> -->
-<!-- <p><strong>Judge Skill:</strong> {{ current_user.judge_skill or '—' }}</p> -->
+</div>
+
+<div class="mb-3">
+  <span class="badge badge-blue">Debates {{ current_user.debate_count or 0 }}</span>
+  <span class="badge badge-gray">BP {{ '%.0f'|format(current_user.elo_rating) }}</span>
+  <span class="badge badge-amber">σ {{ '%.0f'|format(current_user.elo_sigma) }}</span>
+</div>
+
 <p><strong>Languages:</strong> {{ current_user.languages or '—' }}</p>
-<p><strong>Debates Participated:</strong> {{ current_user.debate_count or 0 }}</p>
-<p><strong>BP Ranking:</strong> {{ '%.0f'|format(current_user.elo_rating) }} &plusmn; {{ '%.0f'|format(current_user.elo_sigma) }}</p>
 <p><strong>OPD Skill:</strong>
   {% if opd_result_count == 0 %}
     None


### PR DESCRIPTION
## Summary
- add dark blue/gray themed stylesheet and sticky navbar
- redesign dashboard, debate, analytics, profile and admin users templates
- add grid utilities, cards, tabs, badges, progress bars and table polish

## Testing
- `pytest`
- `python start.py` & playwright screenshots of dashboard, debate, analytics, profile, admin users

------
https://chatgpt.com/codex/tasks/task_e_68967f5a2bd88330935b2959748bf6b5