### PR TITLE
Ensure balanced room counts for assignments

### DIFF
--- a/app/logic/assign.py
+++ b/app/logic/assign.py
@@ -61,15 +61,23 @@ def _compute_room_counts(total, settings):
     if remaining > capacity:
         return None
 
-    for i in range(len(settings)):
-        if remaining <= 0:
-            break
-        add = min(maxs[i] - numbers[i], remaining)
-        numbers[i] += add
-        remaining -= add
-
-    if remaining != 0:
-        return None
+    # Distribute remaining participants in a round-robin fashion so that no
+    # room ends up more than one participant larger than another (where
+    # permitted by the max bounds).
+    while remaining > 0:
+        progressed = False
+        for i in range(len(settings)):
+            if remaining <= 0:
+                break
+            if numbers[i] < maxs[i]:
+                numbers[i] += 1
+                remaining -= 1
+                progressed = True
+        if not progressed:
+            # No room could accept more participants even though ``remaining``
+            # suggests otherwise. This should not happen due to the capacity
+            # check above, but guard against misconfiguration.
+            return None
     return numbers
 
 

--- a/tests/test_room_counts.py
+++ b/tests/test_room_counts.py
@@ -1,0 +1,18 @@
+import pytest
+
+from app.logic.assign import _compute_room_counts
+
+
+def test_even_distribution_two_rooms():
+    settings = [(7, 12), (7, 12)]
+    counts = _compute_room_counts(17, settings)
+    assert counts == [9, 8]
+
+
+def test_even_distribution_multiple_rooms():
+    settings = [(2, 5), (2, 5), (2, 5)]
+    counts = _compute_room_counts(10, settings)
+    assert sum(counts) == 10
+    assert max(counts) - min(counts) <= 1
+    for c, (mn, mx) in zip(counts, settings):
+        assert mn <= c <= mx


### PR DESCRIPTION
## Summary
- Distribute extra participants across rooms in a round-robin manner to avoid overfull rooms
- Cover even distribution logic with new unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689dd7535d7483309ec85090b2e6716b