### PR TITLE
Experience updates, free speech preference, refactoring

### DIFF
--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -5,25 +5,31 @@ import itertools
 from app.models import Debate, Topic, Vote, User
 from app.extensions import db
 from app.logic.assign import assign_speakers, _compute_room_counts
-from app.utils import compute_winning_topic, reset_prefer_judging
+from app.utils import compute_winning_topic, reset_prefer_judging, reset_prefer_free
 from datetime import datetime, timedelta
 from app import socketio
 
 from . import admin_bp
 
+
 # Decorator for admin-only views
 def admin_required(f):
     from functools import wraps
+
     @wraps(f)
     def decorated_function(*args, **kwargs):
-        if not current_user.is_authenticated or not getattr(current_user, 'is_admin', False):
-            flash('Admin access required.', 'danger')
-            return redirect(url_for('main.dashboard'))
+        if not current_user.is_authenticated or not getattr(
+            current_user, "is_admin", False
+        ):
+            flash("Admin access required.", "danger")
+            return redirect(url_for("main.dashboard"))
         return f(*args, **kwargs)
+
     return decorated_function
 
+
 # Admin dashboard: list debates, option to add
-@admin_bp.route('/admin')
+@admin_bp.route("/admin")
 @login_required
 @admin_required
 def admin_dashboard():
@@ -34,60 +40,67 @@ def admin_dashboard():
         topic_ids = [t.id for t in debate.topics]
         if topic_ids:
             # Query for unique user_ids who voted for any topic in this debate
-            count = (db.session.query(Vote.user_id)
-                     .filter(Vote.topic_id.in_(topic_ids))
-                     .distinct()
-                     .count())
+            count = (
+                db.session.query(Vote.user_id)
+                .filter(Vote.topic_id.in_(topic_ids))
+                .distinct()
+                .count()
+            )
         else:
             count = 0
         voter_counts[debate.id] = count
     print(voter_counts)
-    return render_template("admin/dashboard.html", debates=debates, voter_counts=voter_counts)
+    return render_template(
+        "admin/dashboard.html", debates=debates, voter_counts=voter_counts
+    )
 
 
 # Create debate
-@admin_bp.route('/admin/create_debate', methods=['GET', 'POST'])
+@admin_bp.route("/admin/create_debate", methods=["GET", "POST"])
 @login_required
 @admin_required
 def create_debate():
-    if request.method == 'POST':
-        title = request.form['title']
-        style = request.form['style']
-        assignment_mode = request.form.get('assignment_mode', 'Random')
-        if not title or style not in ['OPD', 'BP', 'Dynamic']:
-            flash('Please fill all fields correctly.', 'danger')
-            return redirect(url_for('admin.create_debate'))
-        debate = Debate(title=title, style=style,
-                        assignment_mode=assignment_mode, active=False)
+    if request.method == "POST":
+        title = request.form["title"]
+        style = request.form["style"]
+        assignment_mode = request.form.get("assignment_mode", "Random")
+        if not title or style not in ["OPD", "BP", "Dynamic"]:
+            flash("Please fill all fields correctly.", "danger")
+            return redirect(url_for("admin.create_debate"))
+        debate = Debate(
+            title=title, style=style, assignment_mode=assignment_mode, active=False
+        )
         db.session.add(debate)
         reset_prefer_judging()
         db.session.commit()
-        flash('Debate created!', 'success')
-        return redirect(url_for('admin.admin_dashboard'))
-    return render_template('admin/create_debate.html')
+        flash("Debate created!", "success")
+        return redirect(url_for("admin.admin_dashboard"))
+    return render_template("admin/create_debate.html")
+
 
 # Add topic to debate
-@admin_bp.route('/admin/<int:debate_id>/add_topic', methods=['GET', 'POST'])
+@admin_bp.route("/admin/<int:debate_id>/add_topic", methods=["GET", "POST"])
 @login_required
 @admin_required
 def add_topic(debate_id):
     debate = Debate.query.get_or_404(debate_id)
-    if request.method == 'POST':
-        text = request.form['text']
-        factsheet = request.form.get('factsheet')
+    if request.method == "POST":
+        text = request.form["text"]
+        factsheet = request.form.get("factsheet")
         if not text:
-            flash('Please enter a topic.', 'danger')
-            return redirect(url_for('admin.add_topic', debate_id=debate_id))
+            flash("Please enter a topic.", "danger")
+            return redirect(url_for("admin.add_topic", debate_id=debate_id))
         topic = Topic(text=text, factsheet=factsheet, debate_id=debate_id)
         db.session.add(topic)
         db.session.commit()
-        socketio.emit('topic_list_update', {'debate_id': debate_id})
-        flash('Topic added.', 'success')
-        return redirect(url_for('admin.admin_dashboard'))
-    return render_template('admin/add_topic.html', debate=debate)
+        socketio.emit("topic_list_update", {"debate_id": debate_id})
+        flash("Topic added.", "success")
+        return redirect(url_for("admin.admin_dashboard"))
+    return render_template("admin/add_topic.html", debate=debate)
+
 
 # Toggle voting
-@admin_bp.route('/admin/<int:debate_id>/toggle_voting')
+@admin_bp.route("/admin/<int:debate_id>/toggle_voting")
 @login_required
 @admin_required
 def toggle_voting(debate_id):
@@ -103,7 +116,7 @@ def toggle_voting(debate_id):
                 max_votes = max(votes.values())
                 tied = [str(tid) for tid, c in votes.items() if c == max_votes]
                 if len(tied) > 1:
-                    debate.second_voting_topics = ','.join(tied)
+                    debate.second_voting_topics = ",".join(tied)
                 else:
                     debate.second_voting_topics = None
     db.session.commit()
@@ -111,72 +124,75 @@ def toggle_voting(debate_id):
     if not debate.voting_open and not debate.second_voting_open:
         winner = compute_winning_topic(debate)
         if winner:
-            socketio.emit('winning_topic', {
-                'debate_id': debate_id,
-                'topic': {
-                    'id': winner.id,
-                    'text': winner.text,
-                    'factsheet': winner.factsheet,
-                }
-            })
-    socketio.emit('debate_status', {
-        'debate_id': debate_id,
-        'voting_open': debate.voting_open,
-        'second_voting_open': debate.second_voting_open
-    })
-    socketio.emit('debate_list_update', {
-        'debate_id': debate_id,
-        'voting_open': debate.voting_open
-    })
+            socketio.emit(
+                "winning_topic",
+                {
+                    "debate_id": debate_id,
+                    "topic": {
+                        "id": winner.id,
+                        "text": winner.text,
+                        "factsheet": winner.factsheet,
+                    },
+                },
+            )
+    socketio.emit(
+        "debate_status",
+        {
+            "debate_id": debate_id,
+            "voting_open": debate.voting_open,
+            "second_voting_open": debate.second_voting_open,
+        },
+    )
+    socketio.emit(
+        "debate_list_update",
+        {"debate_id": debate_id, "voting_open": debate.voting_open},
+    )
     status = "opened" if debate.voting_open else "closed"
-    flash(f'Voting {status} for {debate.title}.', 'info')
-    return redirect(url_for('admin.admin_dashboard'))
+    flash(f"Voting {status} for {debate.title}.", "info")
+    return redirect(url_for("admin.admin_dashboard"))
 
-@admin_bp.route('/admin/<int:debate_id>/open_second_voting')
+
+@admin_bp.route("/admin/<int:debate_id>/open_second_voting")
 @login_required
 @admin_required
 def open_second_voting(debate_id):
     debate = Debate.query.get_or_404(debate_id)
     if not debate.second_voting_topics:
-        flash('No tie detected.', 'warning')
-        return redirect(url_for('admin.admin_dashboard'))
+        flash("No tie detected.", "warning")
+        return redirect(url_for("admin.admin_dashboard"))
     debate.voting_open = True
     debate.second_voting_open = True
     topic_ids = db.session.query(Topic.id).filter(Topic.debate_id == debate_id)
-    Vote.query.filter(
-        Vote.round == 2,
-        Vote.topic_id.in_(topic_ids)
-    ).delete(synchronize_session=False)
+    Vote.query.filter(Vote.round == 2, Vote.topic_id.in_(topic_ids)).delete(
+        synchronize_session=False
+    )
     db.session.commit()
-    socketio.emit('debate_status', {
-        'debate_id': debate_id,
-        'voting_open': True,
-        'second_voting_open': True
-    })
-    socketio.emit('debate_list_update', {
-        'debate_id': debate_id,
-        'voting_open': True
-    })
-    flash('Second voting opened.', 'info')
-    return redirect(url_for('admin.admin_dashboard'))
+    socketio.emit(
+        "debate_status",
+        {"debate_id": debate_id, "voting_open": True, "second_voting_open": True},
+    )
+    socketio.emit("debate_list_update", {"debate_id": debate_id, "voting_open": True})
+    flash("Second voting opened.", "info")
+    return redirect(url_for("admin.admin_dashboard"))
+
 
 # Toggle active status
-@admin_bp.route('/admin/<int:debate_id>/toggle_active')
+@admin_bp.route("/admin/<int:debate_id>/toggle_active")
 @login_required
 @admin_required
 def toggle_active(debate_id):
     debate = Debate.query.get_or_404(debate_id)
     debate.active = not debate.active
     db.session.commit()
-    socketio.emit('debate_list_update', {
-        'debate_id': debate_id,
-        'active': debate.active
-    })
+    socketio.emit(
+        "debate_list_update", {"debate_id": debate_id, "active": debate.active}
+    )
     status = "activated" if debate.active else "deactivated"
-    flash(f'Debate {status}.', 'info')
-    return redirect(url_for('admin.admin_dashboard'))
-    
-@admin_bp.route('/admin/debate/<int:debate_id>/vote_stats')
+    flash(f"Debate {status}.", "info")
+    return redirect(url_for("admin.admin_dashboard"))
+
+
+@admin_bp.route("/admin/debate/<int:debate_id>/vote_stats")
 @login_required
 @admin_required
 def vote_stats(debate_id):
@@ -204,222 +220,254 @@ def vote_stats(debate_id):
     total_users = len(eligible_user_ids)
     voted_users = len(voted_user_ids)
 
-    return jsonify({
-        'total_users': total_users,
-        'voted_users': voted_users
-    })
+    return jsonify({"total_users": total_users, "voted_users": voted_users})
+
 
 # Edit debate
-@admin_bp.route('/admin/<int:debate_id>/edit', methods=['GET', 'POST'])
+@admin_bp.route("/admin/<int:debate_id>/edit", methods=["GET", "POST"])
 @login_required
 @admin_required
 def edit_debate(debate_id):
     debate = Debate.query.get_or_404(debate_id)
-    if request.method == 'POST':
-        title = request.form['title']
-        style = request.form['style']
-        assignment_mode = request.form.get('assignment_mode', debate.assignment_mode)
-        if title and style in ['OPD', 'BP', 'Dynamic']:
+    if request.method == "POST":
+        title = request.form["title"]
+        style = request.form["style"]
+        assignment_mode = request.form.get("assignment_mode", debate.assignment_mode)
+        if title and style in ["OPD", "BP", "Dynamic"]:
             debate.title = title
             debate.style = style
             debate.assignment_mode = assignment_mode
             db.session.commit()
-            flash('Debate updated.', 'success')
-            return redirect(url_for('admin.admin_dashboard'))
-        flash('Invalid input.', 'danger')
-    return render_template('admin/edit_debate.html', debate=debate)
+            flash("Debate updated.", "success")
+            return redirect(url_for("admin.admin_dashboard"))
+        flash("Invalid input.", "danger")
+    return render_template("admin/edit_debate.html", debate=debate)
+
 
 # Delete debate
-@admin_bp.route('/admin/<int:debate_id>/delete', methods=['POST'])
+@admin_bp.route("/admin/<int:debate_id>/delete", methods=["POST"])
 @login_required
 @admin_required
 def delete_debate(debate_id):
     debate = Debate.query.get_or_404(debate_id)
     db.session.delete(debate)
     db.session.commit()
-    flash('Debate deleted.', 'info')
-    return redirect(url_for('admin.admin_dashboard'))
+    flash("Debate deleted.", "info")
+    return redirect(url_for("admin.admin_dashboard"))
+
 
 # Edit topic
-@admin_bp.route('/admin/topic/<int:topic_id>/edit', methods=['GET', 'POST'])
+@admin_bp.route("/admin/topic/<int:topic_id>/edit", methods=["GET", "POST"])
 @login_required
 @admin_required
 def edit_topic(topic_id):
     topic = Topic.query.get_or_404(topic_id)
-    if request.method == 'POST':
-        text = request.form['text']
-        factsheet = request.form.get('factsheet')
+    if request.method == "POST":
+        text = request.form["text"]
+        factsheet = request.form.get("factsheet")
         if text:
             topic.text = text
             topic.factsheet = factsheet
             db.session.commit()
-            socketio.emit('topic_list_update', {'debate_id': topic.debate_id})
-            flash('Topic updated.', 'success')
-            return redirect(url_for('admin.admin_dashboard'))
-        flash('Invalid input.', 'danger')
-    return render_template('admin/edit_topic.html', topic=topic)
+            socketio.emit("topic_list_update", {"debate_id": topic.debate_id})
+            flash("Topic updated.", "success")
+            return redirect(url_for("admin.admin_dashboard"))
+        flash("Invalid input.", "danger")
+    return render_template("admin/edit_topic.html", topic=topic)
+
 
 # Delete topic
-@admin_bp.route('/admin/topic/<int:topic_id>/delete', methods=['POST'])
+@admin_bp.route("/admin/topic/<int:topic_id>/delete", methods=["POST"])
 @login_required
 @admin_required
 def delete_topic(topic_id):
     topic = Topic.query.get_or_404(topic_id)
     db.session.delete(topic)
     db.session.commit()
-    socketio.emit('topic_list_update', {'debate_id': topic.debate_id})
-    flash('Topic deleted.', 'info')
-    return redirect(url_for('admin.admin_dashboard'))
+    socketio.emit("topic_list_update", {"debate_id": topic.debate_id})
+    flash("Topic deleted.", "info")
+    return redirect(url_for("admin.admin_dashboard"))
 
-@admin_bp.route('/admin/users')
+
+@admin_bp.route("/admin/users")
 @login_required
 @admin_required
 def manage_users():
     from app.models import User
+
     users = User.query.all()
-    return render_template('admin/users.html', users=users)
+    return render_template("admin/users.html", users=users)
 
 
-@admin_bp.route('/admin/pending_users')
+@admin_bp.route("/admin/pending_users")
 @login_required
 @admin_required
 def manage_pending_users():
     from app.models import PendingUser
+
     pending = PendingUser.query.all()
-    return render_template('admin/pending_users.html', pending_users=pending)
+    return render_template("admin/pending_users.html", pending_users=pending)
 
 
-@admin_bp.route('/admin/pending_users/<int:pending_id>/confirm', methods=['POST'])
+@admin_bp.route("/admin/pending_users/<int:pending_id>/confirm", methods=["POST"])
 @login_required
 @admin_required
 def confirm_pending_user(pending_id):
     from app.models import PendingUser, User
+
     p = PendingUser.query.get_or_404(pending_id)
-    user = User(first_name=p.first_name, last_name=p.last_name, email=p.email, password=p.password)
+    user = User(
+        first_name=p.first_name,
+        last_name=p.last_name,
+        email=p.email,
+        password=p.password,
+    )
     db.session.add(user)
     db.session.delete(p)
     db.session.commit()
-    flash('User confirmed.', 'success')
-    return redirect(url_for('admin.manage_pending_users'))
+    flash("User confirmed.", "success")
+    return redirect(url_for("admin.manage_pending_users"))
 
 
-@admin_bp.route('/admin/pending_users/<int:pending_id>/delete', methods=['POST'])
+@admin_bp.route("/admin/pending_users/<int:pending_id>/delete", methods=["POST"])
 @login_required
 @admin_required
 def delete_pending_user(pending_id):
     from app.models import PendingUser
+
     p = PendingUser.query.get_or_404(pending_id)
     db.session.delete(p)
     db.session.commit()
-    flash('Pending user deleted.', 'info')
-    return redirect(url_for('admin.manage_pending_users'))
+    flash("Pending user deleted.", "info")
+    return redirect(url_for("admin.manage_pending_users"))
 
-@admin_bp.route('/admin/users/<int:user_id>/toggle_admin', methods=['POST'])
+
+@admin_bp.route("/admin/users/<int:user_id>/toggle_admin", methods=["POST"])
 @login_required
 @admin_required
 def toggle_user_admin(user_id):
     from app.models import User
+
     user = User.query.get_or_404(user_id)
     user.is_admin = not user.is_admin
     db.session.commit()
     flash(f"User '{user.first_name} {user.last_name}' admin status changed.", "info")
-    return redirect(url_for('admin.manage_users'))
+    return redirect(url_for("admin.manage_users"))
 
 
-@admin_bp.route('/admin/users/<int:user_id>/edit', methods=['GET', 'POST'])
+@admin_bp.route("/admin/users/<int:user_id>/edit", methods=["GET", "POST"])
 @login_required
 @admin_required
 def edit_user(user_id):
     from app.models import User
+
     user = User.query.get_or_404(user_id)
-    if request.method == 'POST':
-        user.debate_skill = request.form.get('debate_skill') or None
-        user.judge_skill = request.form.get('judge_skill') or None
-        user.languages = request.form.get('languages') or None
-        elo = request.form.get('elo_rating')
-        sigma = request.form.get('elo_sigma')
+    if request.method == "POST":
+        user.debate_skill = request.form.get("debate_skill") or None
+        user.judge_skill = request.form.get("judge_skill") or None
+        user.languages = request.form.get("languages") or None
+        elo = request.form.get("elo_rating")
+        sigma = request.form.get("elo_sigma")
         try:
             if elo:
                 user.elo_rating = float(elo)
         except ValueError:
-            flash('Invalid Elo rating.', 'danger')
+            flash("Invalid Elo rating.", "danger")
         try:
             if sigma:
                 user.elo_sigma = float(sigma)
         except ValueError:
-            flash('Invalid Elo sigma.', 'danger')
+            flash("Invalid Elo sigma.", "danger")
         db.session.commit()
-        flash('User updated.', 'success')
-        return redirect(url_for('admin.manage_users'))
-    return render_template('admin/edit_user.html', user=user)
-    
-@admin_bp.route('/admin/<int:debate_id>/assign', methods=['POST'])
+        flash("User updated.", "success")
+        return redirect(url_for("admin.manage_users"))
+    return render_template("admin/edit_user.html", user=user)
+
+
+@admin_bp.route("/admin/<int:debate_id>/assign", methods=["POST"])
 @login_required
 def run_assign(debate_id):
     if not current_user.is_admin:
         flash("Admin rights required.", "danger")
-        return redirect(url_for('main.dashboard'))
+        return redirect(url_for("main.dashboard"))
 
     from app.models import Debate, User
+
     debate = Debate.query.get_or_404(debate_id)
     # Option: Only assign users who registered or are eligible
     # Subquery: all topic IDs for this debate
-    topic_ids_subq = db.session.query(Topic.id).filter(Topic.debate_id == debate.id).subquery()
+    topic_ids_subq = (
+        db.session.query(Topic.id).filter(Topic.debate_id == debate.id).subquery()
+    )
 
     # Main query: all users who have a vote on one of these topics
-    users = User.query.join(Vote, User.id == Vote.user_id) \
-                      .filter(Vote.topic_id.in_(topic_ids_subq)) \
-                      .distinct().all()
+    users = (
+        User.query.join(Vote, User.id == Vote.user_id)
+        .filter(Vote.topic_id.in_(topic_ids_subq))
+        .distinct()
+        .all()
+    )
 
     # Clean up previous assignments for this debate if re-running
     from app.models import SpeakerSlot
+
     SpeakerSlot.query.filter_by(debate_id=debate.id).delete()
     db.session.commit()
 
-    scenario = request.form.get('scenario')
-    mode = request.form.get('assignment_mode')
+    scenario = request.form.get("scenario")
+    mode = request.form.get("assignment_mode")
     if mode:
         debate.assignment_mode = mode
         db.session.commit()
     ok, msg = assign_speakers(debate, users, scenario=scenario)
     flash(msg, "success" if ok else "danger")
     if ok:
-        socketio.emit('assignments_ready', {'debate_id': debate_id})
-    return redirect(url_for('admin.admin_dashboard'))
+        socketio.emit("assignments_ready", {"debate_id": debate_id})
+    return redirect(url_for("admin.admin_dashboard"))
 
 
 # Display dynamic planning for a Dynamic debate
-@admin_bp.route('/admin/<int:debate_id>/dynamic_plan')
+@admin_bp.route("/admin/<int:debate_id>/dynamic_plan")
 @login_required
 @admin_required
 def dynamic_plan(debate_id):
     debate = Debate.query.get_or_404(debate_id)
     if debate.voting_open:
-        flash('Voting must be closed before planning rooms.', 'warning')
-        return redirect(url_for('admin.admin_dashboard'))
+        flash("Voting must be closed before planning rooms.", "warning")
+        return redirect(url_for("admin.admin_dashboard"))
 
-    topic_ids_subq = db.session.query(Topic.id).filter(Topic.debate_id == debate.id).subquery()
-    users = User.query.join(Vote, User.id == Vote.user_id) \
-                      .filter(Vote.topic_id.in_(topic_ids_subq)) \
-                      .distinct().all()
+    topic_ids_subq = (
+        db.session.query(Topic.id).filter(Topic.debate_id == debate.id).subquery()
+    )
+    users = (
+        User.query.join(Vote, User.id == Vote.user_id)
+        .filter(Vote.topic_id.in_(topic_ids_subq))
+        .distinct()
+        .all()
+    )
 
     groups = {}
     for u in users:
-        skill = u.debate_skill or 'Unknown'
+        skill = u.debate_skill or "Unknown"
         groups.setdefault(skill, []).append(u)
 
     total = len(users)
-    chair_count = sum(1 for u in users if u.judge_skill == 'Chair')
+    chair_count = sum(1 for u in users if u.judge_skill == "Chair")
+
     def eligible_chair(u):
-        if getattr(u, 'judge_skill', '') == 'Chair':
+        if getattr(u, "judge_skill", "") == "Chair":
             return True
-        if getattr(u, 'judge_skill', '') == 'Wing' and getattr(u, 'debate_skill', '') != 'First Timer':
+        if (
+            getattr(u, "judge_skill", "") == "Wing"
+            and getattr(u, "debate_skill", "") != "First Timer"
+        ):
             return True
-        return getattr(u, 'debate_skill', '') != 'First Timer'
+        return getattr(u, "debate_skill", "") != "First Timer"
+
     fallback_chair_count = sum(1 for u in users if eligible_chair(u))
 
     scenarios = []
-    room_types = {'O': ('OPD', 7, 12), 'B': ('BP', 9, 11)}
+    room_types = {"O": ("OPD", 7, 12), "B": ("BP", 9, 11)}
 
     max_rooms = min(5, total // 7) if total else 1
 
@@ -429,16 +477,16 @@ def dynamic_plan(debate_id):
         free = min(max(n - 8, 0), 3)
         speakers = 6 + free
         judges = n - speakers
-        return f'{speakers} speakers, {judges} judges'
+        return f"{speakers} speakers, {judges} judges"
 
     def bp_breakdown(n):
         wings = min(max(n - 9, 0), 3)
         speakers = 8
         judges = 1 + wings
-        return f'{speakers} speakers, {judges} judges'
+        return f"{speakers} speakers, {judges} judges"
 
     for num_rooms in range(1, max_rooms + 1):
-        for combo in itertools.product('OB', repeat=num_rooms):
+        for combo in itertools.product("OB", repeat=num_rooms):
             spec = [room_types[c] for c in combo]
             counts = _compute_room_counts(total, [(s[1], s[2]) for s in spec])
             if not counts:
@@ -446,25 +494,24 @@ def dynamic_plan(debate_id):
             safe = chair_count >= num_rooms
             if not safe and fallback_chair_count < num_rooms:
                 continue
-            desc = ' + '.join(room_types[c][0] for c in combo)
+            desc = " + ".join(room_types[c][0] for c in combo)
             if not safe:
-                desc += ' (unsafe - using fallback Chairs)'
+                desc += " (unsafe - using fallback Chairs)"
             breakdown = []
             for c, count in zip(combo, counts):
-                if c == 'O':
+                if c == "O":
                     breakdown.append(opd_breakdown(count))
                 else:
                     breakdown.append(bp_breakdown(count))
-            scenarios.append({
-                'id': '-'.join(c for c in combo),
-                'desc': desc,
-                'safe': safe,
-                'breakdown': breakdown
-            })
+            scenarios.append(
+                {
+                    "id": "-".join(c for c in combo),
+                    "desc": desc,
+                    "safe": safe,
+                    "breakdown": breakdown,
+                }
+            )
 
-    return render_template('admin/dynamic_plan.html',
-                           debate=debate,
-                           groups=groups,
-                           scenarios=scenarios)
-
-
+    return render_template(
+        "admin/dynamic_plan.html", debate=debate, groups=groups, scenarios=scenarios
+    )

--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -71,6 +71,7 @@ def create_debate():
             title=title, style=style, assignment_mode=assignment_mode, active=False
         )
         db.session.add(debate)
+        reset_prefer_free()
         reset_prefer_judging()
         db.session.commit()
         flash("Debate created!", "success")

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -34,6 +34,9 @@ def dashboard():
     vote_percent = votes_cast = votes_total = user_role = None
     has_slot = False
     is_judge_chair = False
+    is_first_timer = False
+    if getattr(current_user, "debate_skill", "") == "First Timer":
+        is_first_timer = True
 
     winning_topic = None
     if current_debate:
@@ -96,11 +99,13 @@ def dashboard():
         debates=debates,
         single_open=current_debate,
         has_slot=has_slot,
+        is_first_timer=is_first_timer,
         is_judge_chair=is_judge_chair,
         second_voting_open=(
             current_debate.second_voting_open if current_debate else False
         ),
         winning_topic=winning_topic,
+        prefers_free=current_user.prefer_free,
         prefers_judging=current_user.prefer_judging,
     )
 
@@ -180,6 +185,7 @@ def dashboard_debates_json():
             "second_voting_open": d.second_voting_open,
             "assignment_complete": d.assignment_complete,
             "user_role": user_role,
+            "is_first_timer": is_first_timer,
             "is_judge_chair": is_judge_chair,
             "vote_percent": vote_percent,
             "votes_cast": votes_cast,
@@ -363,6 +369,7 @@ def debate_assignments_json(debate_id):
             "room": s.room,
             "user_id": s.user_id,
             "name": f"{s.user.first_name} {s.user.last_name}",
+            "prefer_free": s.user.prefer_free,
             "prefer_judging": s.user.prefer_judging,
         }
         for s in slots

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -240,15 +240,24 @@ def debate_view(debate_id):
                 flash("You can only vote for up to 2 topics per debate.", "danger")
         else:
             # Bump debate_count if this is their first vote in this debate
-            
+
             if user_votes_in_debate == 0 and round_num == 1:
                 if current_user.debate_count is None:
                     current_user.debate_count = 0
                 current_user.debate_count += 1
+                prev_skill = getattr(current_user, "debate_skill", "")
+                if prev_skill == "First Timer" and current_user.debate_count >= 5:
+                    current_user.debate_skill = "Beginner"
+                # TODO count debates where the user judged? maybe with a 0.5 factor?
+                # generally requires a debates_judged variable which should be initialized through the difference of debate_count and existing scores for this user ignoring BP debates
+                # probably best as an admin functionality that is executed once for all users in order to avoid re-evaluating this with every new debate
+                elif prev_skill == "Beginner" and current_user.debate_count >= 15:
+                    current_user.debate_skill = "Intermediate"
+                # step to advanced would make more sense to implement with a dependency on actual scores
             vote = Vote(user_id=current_user.id, topic_id=topic_id, round=round_num)
             db.session.add(vote)
             db.session.commit()
-            
+
             # -- live vote update start --
             now = datetime.utcnow()
             ten_minutes_ago = now - timedelta(minutes=10)

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -12,17 +12,18 @@ from app.utils import compute_winning_topic
 from . import main_bp
 
 
-@main_bp.route('/privacy')
+@main_bp.route("/privacy")
 def privacy():
     """Public privacy policy page."""
-    return render_template('main/privacy.html')
+    return render_template("main/privacy.html")
 
-@main_bp.route('/')
+
+@main_bp.route("/")
 @login_required
 def dashboard():
     # Redirect to survey if user hasn't filled it out
     if not current_user.date_joined_choice:
-        return redirect(url_for('auth.survey'))
+        return redirect(url_for("auth.survey"))
 
     # Get all debates, newest first
     debates = Debate.query.order_by(Debate.id.desc()).all()
@@ -43,8 +44,7 @@ def dashboard():
             topic_ids = [t.id for t in current_debate.topics]
             round_num = 1
         votes = Vote.query.filter(
-            Vote.topic_id.in_(topic_ids),
-            Vote.round == round_num
+            Vote.topic_id.in_(topic_ids), Vote.round == round_num
         ).all()
         voter_ids = set(v.user_id for v in votes)
         votes_cast = len(voter_ids)
@@ -62,24 +62,29 @@ def dashboard():
 
         # Find this user's speaker role (if assigned)
         slot = SpeakerSlot.query.filter_by(
-            debate_id=current_debate.id,
-            user_id=current_user.id
+            debate_id=current_debate.id, user_id=current_user.id
         ).first()
         has_slot = slot is not None
         if slot:
             user_role = f"{slot.role} in Room {slot.room}" if slot.room else slot.role
-            if slot.role == 'Judge-Chair':
+            if slot.role == "Judge-Chair":
                 is_judge_chair = True
 
         winning_topic = compute_winning_topic(current_debate)
-    
+
     # Categorize debates for UI tabs or display
-    active_debates = [d for d in debates if d.active and (not current_debate or d.id != current_debate.id)]
+    active_debates = [
+        d
+        for d in debates
+        if d.active and (not current_debate or d.id != current_debate.id)
+    ]
     past_debates = [d for d in debates if not d.active and d.assignment_complete]
-    upcoming_debates = [d for d in debates if not d.active and not d.assignment_complete]
+    upcoming_debates = [
+        d for d in debates if not d.active and not d.assignment_complete
+    ]
 
     return render_template(
-        'main/dashboard.html',
+        "main/dashboard.html",
         current_debate=current_debate,
         vote_percent=vote_percent,
         votes_cast=votes_cast,
@@ -92,31 +97,43 @@ def dashboard():
         single_open=current_debate,
         has_slot=has_slot,
         is_judge_chair=is_judge_chair,
-        second_voting_open=current_debate.second_voting_open if current_debate else False,
+        second_voting_open=(
+            current_debate.second_voting_open if current_debate else False
+        ),
         winning_topic=winning_topic,
         prefers_judging=current_user.prefer_judging,
     )
 
 
-@main_bp.route('/dashboard/debates_json')
+@main_bp.route("/dashboard/debates_json")
 @login_required
 def dashboard_debates_json():
     debates = Debate.query.order_by(Debate.id.desc()).all()
     open_debates = [d for d in debates if d.active]
     current_debate = open_debates[0] if len(open_debates) == 1 else None
 
-    active_debates = [d for d in debates if d.active and (not current_debate or d.id != current_debate.id)]
+    active_debates = [
+        d
+        for d in debates
+        if d.active and (not current_debate or d.id != current_debate.id)
+    ]
     past_debates = [d for d in debates if not d.active and d.assignment_complete]
-    upcoming_debates = [d for d in debates if not d.active and not d.assignment_complete]
+    upcoming_debates = [
+        d for d in debates if not d.active and not d.assignment_complete
+    ]
 
     def serialize(d):
-        return {
-            'id': d.id,
-            'title': d.title,
-            'style': d.style,
-            'active': d.active,
-            'second_voting_open': d.second_voting_open,
-        } if d else None
+        return (
+            {
+                "id": d.id,
+                "title": d.title,
+                "style": d.style,
+                "active": d.active,
+                "second_voting_open": d.second_voting_open,
+            }
+            if d
+            else None
+        )
 
     def serialize_current(d):
         if not d:
@@ -128,8 +145,7 @@ def dashboard_debates_json():
             topic_ids = [t.id for t in d.topics]
             round_num = 1
         votes = Vote.query.filter(
-            Vote.topic_id.in_(topic_ids),
-            Vote.round == round_num
+            Vote.topic_id.in_(topic_ids), Vote.round == round_num
         ).all()
         voter_ids = set(v.user_id for v in votes)
         votes_cast = len(voter_ids)
@@ -144,70 +160,84 @@ def dashboard_debates_json():
         vote_percent = int((votes_cast / votes_total) * 100) if votes_total else 0
 
         slot = SpeakerSlot.query.filter_by(
-            debate_id=d.id,
-            user_id=current_user.id
+            debate_id=d.id, user_id=current_user.id
         ).first()
         user_role = (
-            f"{slot.role} in Room {slot.room}" if slot and slot.room else slot.role
-        ) if slot else None
-        is_judge_chair = slot.role == 'Judge-Chair' if slot else False
+            (f"{slot.role} in Room {slot.room}" if slot and slot.room else slot.role)
+            if slot
+            else None
+        )
+
+        is_judge_chair = slot.role == "Judge-Chair" if slot else False
         winner = compute_winning_topic(d)
 
         return {
-            'id': d.id,
-            'title': d.title,
-            'style': d.style,
-            'active': d.active,
-            'voting_open': d.voting_open,
-            'second_voting_open': d.second_voting_open,
-            'assignment_complete': d.assignment_complete,
-            'user_role': user_role,
-            'is_judge_chair': is_judge_chair,
-            'vote_percent': vote_percent,
-            'votes_cast': votes_cast,
-            'votes_total': votes_total,
-            'winner_topic': {
-                'id': winner.id,
-                'text': winner.text,
-                'factsheet': winner.factsheet,
-            } if winner else None,
+            "id": d.id,
+            "title": d.title,
+            "style": d.style,
+            "active": d.active,
+            "voting_open": d.voting_open,
+            "second_voting_open": d.second_voting_open,
+            "assignment_complete": d.assignment_complete,
+            "user_role": user_role,
+            "is_judge_chair": is_judge_chair,
+            "vote_percent": vote_percent,
+            "votes_cast": votes_cast,
+            "votes_total": votes_total,
+            "winner_topic": (
+                {
+                    "id": winner.id,
+                    "text": winner.text,
+                    "factsheet": winner.factsheet,
+                }
+                if winner
+                else None
+            ),
         }
 
-    return jsonify({
-        'current_debate': serialize_current(current_debate),
-        'active_debates': [serialize(d) for d in active_debates],
-        'past_debates': [serialize(d) for d in past_debates],
-        'upcoming_debates': [serialize(d) for d in upcoming_debates],
-    })
+    return jsonify(
+        {
+            "current_debate": serialize_current(current_debate),
+            "active_debates": [serialize(d) for d in active_debates],
+            "past_debates": [serialize(d) for d in past_debates],
+            "upcoming_debates": [serialize(d) for d in upcoming_debates],
+        }
+    )
 
 
-@main_bp.route('/debate/<int:debate_id>', methods=['GET', 'POST'])
+@main_bp.route("/debate/<int:debate_id>", methods=["GET", "POST"])
 @login_required
 def debate_view(debate_id):
     if not current_user.date_joined_choice:
-        return redirect(url_for('auth.survey'))
+        return redirect(url_for("auth.survey"))
 
     debate = Debate.query.options(joinedload(Debate.speakerslots)).get_or_404(debate_id)
     topics = debate.second_topics() if debate.second_voting_open else debate.topics
 
     # voting logic
-    if request.method == 'POST' and debate.voting_open:
-        topic_id = int(request.form.get('topic_id'))
+    if request.method == "POST" and debate.voting_open:
+        topic_id = int(request.form.get("topic_id"))
         round_num = 2 if debate.second_voting_open else 1
-        existing_vote = Vote.query.filter_by(user_id=current_user.id, topic_id=topic_id, round=round_num).first()
-        user_votes_in_debate = Vote.query.join(Topic).filter(
-            Vote.user_id == current_user.id,
-            Topic.debate_id == debate_id,
-            Vote.round == round_num
-        ).count()
+        existing_vote = Vote.query.filter_by(
+            user_id=current_user.id, topic_id=topic_id, round=round_num
+        ).first()
+        user_votes_in_debate = (
+            Vote.query.join(Topic)
+            .filter(
+                Vote.user_id == current_user.id,
+                Topic.debate_id == debate_id,
+                Vote.round == round_num,
+            )
+            .count()
+        )
         max_votes = 1 if debate.second_voting_open else 2
         if existing_vote:
-            flash('You have already voted for this topic.', 'warning')
+            flash("You have already voted for this topic.", "warning")
         elif user_votes_in_debate >= max_votes:
             if debate.second_voting_open:
-                flash('You can only vote for one topic in this round.', 'danger')
+                flash("You can only vote for one topic in this round.", "danger")
             else:
-                flash('You can only vote for up to 2 topics per debate.', 'danger')
+                flash("You can only vote for up to 2 topics per debate.", "danger")
         else:
             # Bump debate_count if this is their first vote in this debate
             
@@ -238,36 +268,49 @@ def debate_view(debate_id):
             total_users = len(eligible_user_ids)
             voted_users = len(voted_user_ids)
 
-            socketio.emit('vote_update', {
-                'debate_id': debate_id,
-                'vote_data': {
-                    'total_users': total_users,
-                    'voted_users': voted_users
-                }
-            })
+            socketio.emit(
+                "vote_update",
+                {
+                    "debate_id": debate_id,
+                    "vote_data": {
+                        "total_users": total_users,
+                        "voted_users": voted_users,
+                    },
+                },
+            )
             # -- live vote update end --
-            
-            flash('Your vote has been cast!', 'success')
-        return redirect(url_for('main.debate_view', debate_id=debate_id))
+
+            flash("Your vote has been cast!", "success")
+        return redirect(url_for("main.debate_view", debate_id=debate_id))
 
     # Prepare user vote info for template
     round_num = 2 if debate.second_voting_open else 1
-    topic_ids = debate.second_topic_ids() if debate.second_voting_open else [t.id for t in debate.topics]
-    user_votes = [v.topic_id for v in Vote.query.filter(
-        Vote.user_id == current_user.id,
-        Vote.round == round_num,
-        Vote.topic_id.in_(topic_ids)
-    ).all()]
+    topic_ids = (
+        debate.second_topic_ids()
+        if debate.second_voting_open
+        else [t.id for t in debate.topics]
+    )
+    user_votes = [
+        v.topic_id
+        for v in Vote.query.filter(
+            Vote.user_id == current_user.id,
+            Vote.round == round_num,
+            Vote.topic_id.in_(topic_ids),
+        ).all()
+    ]
     limit = 1 if debate.second_voting_open else 2
     votes_left = limit - len(user_votes)
 
-    return render_template('main/debate.html',
-                           debate=debate,
-                           topics=topics,
-                           user_votes=user_votes,
-                           votes_left=votes_left)
-                           
-@main_bp.route('/debate/<int:debate_id>/assignments')
+    return render_template(
+        "main/debate.html",
+        debate=debate,
+        topics=topics,
+        user_votes=user_votes,
+        votes_left=votes_left,
+    )
+
+
+@main_bp.route("/debate/<int:debate_id>/assignments")
 @login_required
 def debate_assignments(debate_id):
     debate = Debate.query.get_or_404(debate_id)
@@ -277,36 +320,43 @@ def debate_assignments(debate_id):
     for slot in slots:
         slots_by_room.setdefault(slot.room, []).append(slot)
     # Get users by id for lookup
-    user_map = {u.id: u for u in User.query.filter(User.id.in_([s.user_id for s in slots])).all()}
-    return render_template('main/debate_assignments.html',
-                           debate=debate,
-                           slots_by_room=slots_by_room,
-                           user_map=user_map)
+    user_map = {
+        u.id: u
+        for u in User.query.filter(User.id.in_([s.user_id for s in slots])).all()
+    }
+    return render_template(
+        "main/debate_assignments.html",
+        debate=debate,
+        slots_by_room=slots_by_room,
+        user_map=user_map,
+    )
 
-@main_bp.route('/debate/<int:debate_id>/topics_json')
+
+@main_bp.route("/debate/<int:debate_id>/topics_json")
 @login_required
 def debate_topics_json(debate_id):
     debate = Debate.query.get_or_404(debate_id)
     topic_list = debate.second_topics() if debate.second_voting_open else debate.topics
     topics = [
-        {'id': t.id, 'text': t.text, 'factsheet': t.factsheet}
-        for t in topic_list
+        {"id": t.id, "text": t.text, "factsheet": t.factsheet} for t in topic_list
     ]
-    return jsonify({'topics': topics})
+    return jsonify({"topics": topics})
 
-@main_bp.route('/debate/<int:debate_id>/assignments_json')
+
+@main_bp.route("/debate/<int:debate_id>/assignments_json")
 @login_required
 def debate_assignments_json(debate_id):
     debate = Debate.query.get_or_404(debate_id)
     slots = SpeakerSlot.query.filter_by(debate_id=debate_id).all()
     assignments = [
         {
-            'role': s.role,
-            'room': s.room,
-            'user_id': s.user_id,
-            'name': f"{s.user.first_name} {s.user.last_name}",
-            'prefer_judging': s.user.prefer_judging,
-        } for s in slots
+            "role": s.role,
+            "room": s.room,
+            "user_id": s.user_id,
+            "name": f"{s.user.first_name} {s.user.last_name}",
+            "prefer_judging": s.user.prefer_judging,
+        }
+        for s in slots
     ]
 
     slots_by_room = {}
@@ -316,17 +366,17 @@ def debate_assignments_json(debate_id):
     room_styles = {}
     for room, room_slots in slots_by_room.items():
         roles = {sl.role for sl in room_slots}
-        if roles.intersection({'OG', 'OO', 'CG', 'CO'}):
-            room_styles[room] = 'BP'
-        elif roles.intersection({'Gov', 'Opp'}):
-            room_styles[room] = 'OPD'
+        if roles.intersection({"OG", "OO", "CG", "CO"}):
+            room_styles[room] = "BP"
+        elif roles.intersection({"Gov", "Opp"}):
+            room_styles[room] = "OPD"
         else:
             room_styles[room] = debate.style
 
-    return jsonify({'assignments': assignments, 'room_styles': room_styles})
+    return jsonify({"assignments": assignments, "room_styles": room_styles})
 
 
-@main_bp.route('/debate/<int:debate_id>/join', methods=['POST'])
+@main_bp.route("/debate/<int:debate_id>/join", methods=["POST"])
 @login_required
 def debate_join(debate_id):
     debate = Debate.query.get_or_404(debate_id)
@@ -336,7 +386,10 @@ def debate_join(debate_id):
         debate_id=debate_id, user_id=current_user.id
     ).first()
     if existing:
-        return jsonify({'success': False, 'message': 'Already assigned to this debate.'}), 400
+        return (
+            jsonify({"success": False, "message": "Already assigned to this debate."}),
+            400,
+        )
 
     rooms = sorted({s.room for s in debate.speakerslots}) or [1]
 
@@ -346,7 +399,7 @@ def debate_join(debate_id):
             count = SpeakerSlot.query.filter(
                 SpeakerSlot.debate_id == debate_id,
                 SpeakerSlot.room == room,
-                SpeakerSlot.role.like('Judge%'),
+                SpeakerSlot.role.like("Judge%"),
             ).count()
             counts.append((count, room))
         counts.sort()
@@ -358,13 +411,13 @@ def debate_join(debate_id):
                 slot = SpeakerSlot(
                     debate_id=debate_id,
                     user_id=current_user.id,
-                    role='Judge-Wing',
+                    role="Judge-Wing",
                     room=room,
                 )
                 db.session.add(slot)
                 db.session.commit()
-                socketio.emit('assignments_ready', {'debate_id': debate_id})
-                return jsonify({'success': True, 'role': 'Judge-Wing', 'room': room})
+                socketio.emit("assignments_ready", {"debate_id": debate_id})
+                return jsonify({"success": True, "role": "Judge-Wing", "room": room})
         return None
 
     def assign_speaker():
@@ -372,13 +425,12 @@ def debate_join(debate_id):
             roles = {s.role for s in debate.speakerslots if s.room == room}
             # Detect OPD rooms by the presence of Gov/Opp or any Free slot
             is_opd_room = any(
-                r.startswith('Free') or r in {'Gov', 'Opp'}
-                for r in roles
+                r.startswith("Free") or r in {"Gov", "Opp"} for r in roles
             )
             if not is_opd_room:
                 continue
             for idx in range(1, 4):
-                role = f'Free-{idx}'
+                role = f"Free-{idx}"
                 if role not in roles:
                     slot = SpeakerSlot(
                         debate_id=debate_id,
@@ -388,12 +440,12 @@ def debate_join(debate_id):
                     )
                     db.session.add(slot)
                     db.session.commit()
-                    socketio.emit('assignments_ready', {'debate_id': debate_id})
-                    return jsonify({'success': True, 'role': role, 'room': room})
+                    socketio.emit("assignments_ready", {"debate_id": debate_id})
+                    return jsonify({"success": True, "role": role, "room": room})
         return None
 
     # Step 1: Ensure each room has at least two judges
-    if current_user.judge_skill in ('Wing', 'Chair'):
+    if current_user.judge_skill in ("Wing", "Chair"):
         counts = judge_room_counts()
         if counts and counts[0][0] < 2:
             result = assign_judge()
@@ -401,7 +453,7 @@ def debate_join(debate_id):
                 return result
 
     # Step 2 and 3: Respect judging preference or fill speakers first
-    if current_user.prefer_judging and current_user.judge_skill in ('Wing', 'Chair'):
+    if current_user.prefer_judging and current_user.judge_skill in ("Wing", "Chair"):
         result = assign_judge()
         if result:
             return result
@@ -412,14 +464,20 @@ def debate_join(debate_id):
         result = assign_speaker()
         if result:
             return result
-        if current_user.judge_skill in ('Wing', 'Chair'):
+        if current_user.judge_skill in ("Wing", "Chair"):
             result = assign_judge()
             if result:
                 return result
 
-    return jsonify({'success': False, 'message': 'No available slot or judging permission.'}), 400
+    return (
+        jsonify(
+            {"success": False, "message": "No available slot or judging permission."}
+        ),
+        400,
+    )
 
-@main_bp.route('/debate/<int:debate_id>/vote_status_json')
+
+@main_bp.route("/debate/<int:debate_id>/vote_status_json")
 @login_required
 def debate_vote_status_json(debate_id):
     debate = Debate.query.get_or_404(debate_id)
@@ -431,26 +489,30 @@ def debate_vote_status_json(debate_id):
         round_num = 1
         topic_ids = [t.id for t in debate.topics]
         limit = 2
-    user_votes = [v.topic_id for v in Vote.query.filter(
-        Vote.user_id == current_user.id,
-        Vote.round == round_num,
-        Vote.topic_id.in_(topic_ids)
-    ).all()]
+    user_votes = [
+        v.topic_id
+        for v in Vote.query.filter(
+            Vote.user_id == current_user.id,
+            Vote.round == round_num,
+            Vote.topic_id.in_(topic_ids),
+        ).all()
+    ]
     votes_left = limit - len(user_votes)
-    return jsonify({'user_votes': user_votes, 'votes_left': votes_left})
+    return jsonify({"user_votes": user_votes, "votes_left": votes_left})
 
-@main_bp.route('/debate/<int:debate_id>/graphic')
+
+@main_bp.route("/debate/<int:debate_id>/graphic")
 @login_required
 def debate_graphic(debate_id):
     from sqlalchemy.orm import joinedload
+
     debate = Debate.query.options(
-        joinedload(Debate.speakerslots),
-        joinedload(Debate.topics)
+        joinedload(Debate.speakerslots), joinedload(Debate.topics)
     ).get_or_404(debate_id)
 
     if not debate.assignment_complete:
-        flash('Speaker assignments are not complete for this debate.', 'warning')
-        return redirect(url_for('main.debate_view', debate_id=debate_id))
+        flash("Speaker assignments are not complete for this debate.", "warning")
+        return redirect(url_for("main.debate_view", debate_id=debate_id))
 
     # Find current user's slot (may be None if not assigned)
     my_slot = SpeakerSlot.query.filter_by(
@@ -466,19 +528,19 @@ def debate_graphic(debate_id):
     room_styles = {}
     for room, slots in slots_by_room.items():
         roles = {s.role for s in slots}
-        if roles.intersection({'OG', 'OO', 'CG', 'CO'}):
-            room_styles[room] = 'BP'
-        elif roles.intersection({'Gov', 'Opp'}):
-            room_styles[room] = 'OPD'
+        if roles.intersection({"OG", "OO", "CG", "CO"}):
+            room_styles[room] = "BP"
+        elif roles.intersection({"Gov", "Opp"}):
+            room_styles[room] = "OPD"
         else:
             room_styles[room] = debate.style
 
-    active_room = request.args.get('room', type=int)
+    active_room = request.args.get("room", type=int)
     if not active_room:
         active_room = my_slot.room if my_slot else sorted(slots_by_room)[0]
 
     return render_template(
-        'main/graphic.html',
+        "main/graphic.html",
         debate=debate,
         slots_by_room=slots_by_room,
         room_styles=room_styles,

--- a/app/models.py
+++ b/app/models.py
@@ -70,6 +70,7 @@ class User(UserMixin, db.Model):
     debate_skill = db.Column(db.String(24), nullable=True)
     judge_skill = db.Column(db.String(16), nullable=True)
     prefer_judging = db.Column(db.Boolean, default=False)
+    prefer_free = db.Column(db.Boolean, default=False)
     debate_count = db.Column(db.Integer, default=0)
     last_seen = db.Column(db.DateTime, default=datetime.utcnow)
     elo_rating = db.Column(db.Integer, default=1000)

--- a/app/models.py
+++ b/app/models.py
@@ -5,37 +5,42 @@ from flask_login import UserMixin
 from enum import Enum
 from datetime import datetime
 
+
 class JoinTimeEnum(db.Enum):
-    first = 'first'
-    less2m = '<2m'
-    less6m = '2m-6m'
-    less1y = '6m-1y'
-    less2y = '1y-2y'
-    more2y = '>2y'
+    first = "first"
+    less2m = "<2m"
+    less6m = "2m-6m"
+    less1y = "6m-1y"
+    less2y = "1y-2y"
+    more2y = ">2y"
+
 
 class JudgeChoiceEnum(db.Enum):
-    no = 'no'
-    wing = 'wing'
-    chair = 'chair'
+    no = "no"
+    wing = "wing"
+    chair = "chair"
+
 
 class DebateSkillEnum(db.Enum):
-    first_timer = 'First Timer'
-    beginner = 'Beginner'
-    intermediate = 'Intermediate'
-    advanced = 'Advanced'
-    expert = 'Expert'
+    first_timer = "First Timer"
+    beginner = "Beginner"
+    intermediate = "Intermediate"
+    advanced = "Advanced"
+    expert = "Expert"
+
 
 class JudgeSkillEnum(db.Enum):
-    cant_judge = 'Cant judge'
-    wing = 'Wing'
-    chair = 'Chair'
+    cant_judge = "Cant judge"
+    wing = "Wing"
+    chair = "Chair"
+
 
 # Assignment mode for distributing speakers
 class AssignmentModeEnum(db.Enum):
-    true_random = 'True random'
-    random = 'Random'
-    skill_based = 'Skill based'
-    pro_am = 'ProAm'
+    true_random = "True random"
+    random = "Random"
+    skill_based = "Skill based"
+    pro_am = "ProAm"
 
 
 class PendingUser(db.Model):
@@ -55,35 +60,37 @@ class User(UserMixin, db.Model):
     email = db.Column(db.String(120), unique=True, nullable=False)
     password = db.Column(db.String(256), nullable=False)  # hashed password
     is_admin = db.Column(db.Boolean, default=False)
-    date_joined_choice = db.Column(db.String(16), nullable=True)   # stores survey radio answer
-    judge_choice = db.Column(db.String(8), nullable=True)          # stores survey radio answer
-    languages = db.Column(db.String(64), nullable=True)            # comma separated list of languages
+    date_joined_choice = db.Column(
+        db.String(16), nullable=True
+    )  # stores survey radio answer
+    judge_choice = db.Column(db.String(8), nullable=True)  # stores survey radio answer
+    languages = db.Column(
+        db.String(64), nullable=True
+    )  # comma separated list of languages
     debate_skill = db.Column(db.String(24), nullable=True)
     judge_skill = db.Column(db.String(16), nullable=True)
     prefer_judging = db.Column(db.Boolean, default=False)
     debate_count = db.Column(db.Integer, default=0)
     last_seen = db.Column(db.DateTime, default=datetime.utcnow)
     elo_rating = db.Column(db.Integer, default=1000)
-    elo_sigma = db.Column(db.Float, default=1000/3)
+    elo_sigma = db.Column(db.Float, default=1000 / 3)
     opd_skill = db.Column(db.Float, nullable=True)
 
     # Relationship: which votes has this user cast?
-    votes = db.relationship('Vote', back_populates='user', cascade='all, delete-orphan')
-    slots = db.relationship('SpeakerSlot', backref='user', lazy='dynamic')
-    opd_results = db.relationship('OpdResult', backref='user', lazy='dynamic')
-    elo_logs = db.relationship('EloLog', backref='user', lazy='dynamic')
-    
+    votes = db.relationship("Vote", back_populates="user", cascade="all, delete-orphan")
+    slots = db.relationship("SpeakerSlot", backref="user", lazy="dynamic")
+    opd_results = db.relationship("OpdResult", backref="user", lazy="dynamic")
+    elo_logs = db.relationship("EloLog", backref="user", lazy="dynamic")
+
     def get_slot_for_debate(self, debate_id):
         from app.models import SpeakerSlot
+
         return SpeakerSlot.query.filter_by(debate_id=debate_id, user_id=self.id).first()
 
     def recent_opd_results(self, n=5):
         return (
             OpdResult.query.join(Debate, OpdResult.debate_id == Debate.id)
-            .filter(
-                OpdResult.user_id == self.id,
-                Debate.style == "OPD"
-            )
+            .filter(OpdResult.user_id == self.id, Debate.style == "OPD")
             .order_by(OpdResult.id.desc())
             .limit(n)
             .all()
@@ -98,10 +105,7 @@ class User(UserMixin, db.Model):
     def update_opd_skill(self, n=5):
         results = (
             OpdResult.query.join(Debate, OpdResult.debate_id == Debate.id)
-            .filter(
-                OpdResult.user_id == self.id,
-                Debate.style == "OPD"
-            )
+            .filter(OpdResult.user_id == self.id, Debate.style == "OPD")
             .order_by(OpdResult.id.desc())
             .limit(n)
             .all()
@@ -115,33 +119,26 @@ class User(UserMixin, db.Model):
     def opd_result_count(self):
         return (
             OpdResult.query.join(Debate, OpdResult.debate_id == Debate.id)
-            .filter(
-                OpdResult.user_id == self.id,
-                Debate.style == "OPD"
-            )
+            .filter(OpdResult.user_id == self.id, Debate.style == "OPD")
             .count()
         )
 
     def __repr__(self):
-        return f'<User {self.first_name} {self.last_name}>'
+        return f"<User {self.first_name} {self.last_name}>"
+
 
 # Debate model: stores debate event details
 class Debate(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     title = db.Column(db.String(140), nullable=False)
     style = db.Column(
-        db.Enum('OPD', 'BP', 'Dynamic', name='debate_style'),
-        nullable=False
+        db.Enum("OPD", "BP", "Dynamic", name="debate_style"), nullable=False
     )
     assignment_mode = db.Column(
         db.Enum(
-            'True random',
-            'Random',
-            'Skill based',
-            'ProAm',
-            name='assignment_mode'
+            "True random", "Random", "Skill based", "ProAm", name="assignment_mode"
         ),
-        default='Random'
+        default="Random",
     )
     voting_open = db.Column(db.Boolean, default=True)
     second_voting_open = db.Column(db.Boolean, default=False)
@@ -149,127 +146,136 @@ class Debate(db.Model):
     active = db.Column(db.Boolean, default=False)
 
     # Relationship: which topics belong to this debate?
-    topics = db.relationship('Topic', back_populates='debate', cascade='all, delete-orphan')
-    slots = db.relationship('SpeakerSlot', backref='debate', lazy='dynamic')
-    speakerslots = db.relationship(
-        'SpeakerSlot', backref='debate_ref', lazy=True, cascade="all, delete-orphan"
+    topics = db.relationship(
+        "Topic", back_populates="debate", cascade="all, delete-orphan"
     )
-    
+    slots = db.relationship("SpeakerSlot", backref="debate", lazy="dynamic")
+    speakerslots = db.relationship(
+        "SpeakerSlot", backref="debate_ref", lazy=True, cascade="all, delete-orphan"
+    )
+
     assignment_complete = db.Column(db.Boolean, default=False)
 
     def second_topic_ids(self):
         if not self.second_voting_topics:
             return []
-        return [int(tid) for tid in self.second_voting_topics.split(',') if tid]
+        return [int(tid) for tid in self.second_voting_topics.split(",") if tid]
 
     def second_topics(self):
         ids = set(self.second_topic_ids())
         return [t for t in self.topics if t.id in ids]
 
     def __repr__(self):
-        return f'<Debate {self.title} ({self.style})>'
+        return f"<Debate {self.title} ({self.style})>"
+
 
 # Topic model: a possible motion for a debate
 class Topic(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     text = db.Column(db.String(240), nullable=False)
     factsheet = db.Column(db.Text, nullable=True)
-    debate_id = db.Column(db.Integer, db.ForeignKey('debate.id'), nullable=False)
+    debate_id = db.Column(db.Integer, db.ForeignKey("debate.id"), nullable=False)
 
     # Relationship: back to debate
-    debate = db.relationship('Debate', back_populates='topics')
+    debate = db.relationship("Debate", back_populates="topics")
 
     # Relationship: votes for this topic
-    votes = db.relationship('Vote', back_populates='topic', cascade='all, delete-orphan')
+    votes = db.relationship(
+        "Vote", back_populates="topic", cascade="all, delete-orphan"
+    )
 
     def __repr__(self):
-        return f'<Topic {self.text[:30]}...>'
+        return f"<Topic {self.text[:30]}...>"
+
 
 # Vote model: represents a user's vote for a topic
 class Vote(db.Model):
     id = db.Column(db.Integer, primary_key=True)
-    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
-    topic_id = db.Column(db.Integer, db.ForeignKey('topic.id'), nullable=False)
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+    topic_id = db.Column(db.Integer, db.ForeignKey("topic.id"), nullable=False)
     round = db.Column(db.Integer, default=1)
 
     # Relationships
-    user = db.relationship('User', back_populates='votes')
-    topic = db.relationship('Topic', back_populates='votes')
+    user = db.relationship("User", back_populates="votes")
+    topic = db.relationship("Topic", back_populates="votes")
 
     # Enforce: a user can only vote for a given topic once
     __table_args__ = (
-        db.UniqueConstraint('user_id', 'topic_id', 'round', name='_user_topic_round_uc'),
+        db.UniqueConstraint(
+            "user_id", "topic_id", "round", name="_user_topic_round_uc"
+        ),
     )
 
     def __repr__(self):
-        return f'<Vote user={self.user_id} topic={self.topic_id}>'
+        return f"<Vote user={self.user_id} topic={self.topic_id}>"
+
 
 JOIN_SKILL = {
-    'first': 'First Timer',
-    '<2m': 'Beginner',
-    '2m-6m': 'Beginner',
-    '6m-1y': 'Intermediate',
-    '1y-2y': 'Advanced',
-    '>2y': 'Expert'
+    "first": "First Timer",
+    "<2m": "Beginner",
+    "2m-6m": "Beginner",
+    "6m-1y": "Intermediate",
+    "1y-2y": "Advanced",
+    ">2y": "Expert",
 }
-JUDGE_SKILL = {
-    'no': 'Cant judge',
-    'wing': 'Wing',
-    'chair': 'Chair'
-}
+JUDGE_SKILL = {"no": "Cant judge", "wing": "Wing", "chair": "Chair"}
+
 
 def apply_skills(user):
-    user.debate_skill = JOIN_SKILL.get(user.date_joined_choice, 'First Timer')
-    user.judge_skill = JUDGE_SKILL.get(user.judge_choice, 'Cant judge')
-    
+    user.debate_skill = JOIN_SKILL.get(user.date_joined_choice, "First Timer")
+    user.judge_skill = JUDGE_SKILL.get(user.judge_choice, "Cant judge")
+
+
 class SpeakerSlot(db.Model):
     id = db.Column(db.Integer, primary_key=True)
-    debate_id = db.Column(db.Integer, db.ForeignKey('debate.id'), nullable=False)
-    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
-    role = db.Column(db.String(32), nullable=False)    # e.g. "Gov-1", "Judge-Chair"
-    room = db.Column(db.Integer, default=1)            # For split debates (1 or 2)
+    debate_id = db.Column(db.Integer, db.ForeignKey("debate.id"), nullable=False)
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+    role = db.Column(db.String(32), nullable=False)  # e.g. "Gov-1", "Judge-Chair"
+    room = db.Column(db.Integer, default=1)  # For split debates (1 or 2)
     # Ensure each user is only assigned once per debate per room
-    __table_args__ = (db.UniqueConstraint('debate_id', 'user_id', 'room', name='_debate_user_room_uc'),)
+    __table_args__ = (
+        db.UniqueConstraint(
+            "debate_id", "user_id", "room", name="_debate_user_room_uc"
+        ),
+    )
 
 
 class Score(db.Model):
     id = db.Column(db.Integer, primary_key=True)
-    debate_id = db.Column(db.Integer, db.ForeignKey('debate.id'), nullable=False)
-    speaker_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
-    judge_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    debate_id = db.Column(db.Integer, db.ForeignKey("debate.id"), nullable=False)
+    speaker_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+    judge_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
     value = db.Column(db.Integer, nullable=False)
     __table_args__ = (
-        db.UniqueConstraint('debate_id', 'speaker_id', 'judge_id', name='score_unique'),
+        db.UniqueConstraint("debate_id", "speaker_id", "judge_id", name="score_unique"),
     )
 
 
 class BpRank(db.Model):
     id = db.Column(db.Integer, primary_key=True)
-    debate_id = db.Column(db.Integer, db.ForeignKey('debate.id'), nullable=False)
+    debate_id = db.Column(db.Integer, db.ForeignKey("debate.id"), nullable=False)
     team = db.Column(db.String(8), nullable=False)
     rank = db.Column(db.Integer, nullable=False)
-    __table_args__ = (
-        db.UniqueConstraint('debate_id', 'team', name='bp_rank_unique'),
-    )
+    __table_args__ = (db.UniqueConstraint("debate_id", "team", name="bp_rank_unique"),)
 
 
 class OpdResult(db.Model):
     id = db.Column(db.Integer, primary_key=True)
-    debate_id = db.Column(db.Integer, db.ForeignKey('debate.id'), nullable=False)
-    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    debate_id = db.Column(db.Integer, db.ForeignKey("debate.id"), nullable=False)
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
     points = db.Column(db.Float)
     __table_args__ = (
-        db.UniqueConstraint('debate_id', 'user_id', name='opd_result_unique'),
+        db.UniqueConstraint("debate_id", "user_id", name="opd_result_unique"),
     )
 
 
 class EloLog(db.Model):
     id = db.Column(db.Integer, primary_key=True)
-    debate_id = db.Column(db.Integer, db.ForeignKey('debate.id'), nullable=False)
-    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    debate_id = db.Column(db.Integer, db.ForeignKey("debate.id"), nullable=False)
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
     old_elo = db.Column(db.Float, nullable=False)
     new_elo = db.Column(db.Float, nullable=False)
     change = db.Column(db.Float, nullable=False)
     __table_args__ = (
-        db.UniqueConstraint('debate_id', 'user_id', name='elo_log_unique'),
+        db.UniqueConstraint("debate_id", "user_id", name="elo_log_unique"),
     )

--- a/app/profile/routes.py
+++ b/app/profile/routes.py
@@ -110,25 +110,37 @@ def view():
             }
         )
 
-    return render_template('profile/view.html', opd_result_count=opd_result_count, recent_debates=recent_debates)
+    return render_template(
+        "profile/view.html",
+        opd_result_count=opd_result_count,
+        recent_debates=recent_debates,
+    )
 
 
-@profile_bp.route('/profile/prefer_judging', methods=['POST'])
+@profile_bp.route("/profile/prefer_free", methods=["POST"])
+@login_required
+def prefer_free():
+    data = request.get_json() or {}
+    pref = bool(data.get("prefer_free"))
+    current_user.prefer_free = pref
+    db.session.commit()
+    return jsonify({"prefer_free": current_user.prefer_free})
+
+
+@profile_bp.route("/profile/prefer_judging", methods=["POST"])
 @login_required
 def prefer_judging():
     data = request.get_json() or {}
-    pref = bool(data.get('prefer_judging'))
+    pref = bool(data.get("prefer_judging"))
     current_user.prefer_judging = pref
     db.session.commit()
-    return jsonify({'prefer_judging': current_user.prefer_judging})
+    return jsonify({"prefer_judging": current_user.prefer_judging})
 
 
-@profile_bp.route('/profile/debate/<int:debate_id>/results')
+@profile_bp.route("/profile/debate/<int:debate_id>/results")
 @login_required
 def debate_results(debate_id):
-    debate = Debate.query.options(
-        joinedload(Debate.speakerslots)
-    ).get_or_404(debate_id)
+    debate = Debate.query.options(joinedload(Debate.speakerslots)).get_or_404(debate_id)
 
     slots_by_room = {}
     for slot in debate.speakerslots:

--- a/app/profile/routes.py
+++ b/app/profile/routes.py
@@ -7,15 +7,16 @@ from sqlalchemy.sql import func
 from sqlalchemy.orm import joinedload
 from . import profile_bp
 
-@profile_bp.route('/profile', methods=['GET', 'POST'])
+
+@profile_bp.route("/profile", methods=["GET", "POST"])
 @login_required
 def view():
-    if request.method == 'POST':
+    if request.method == "POST":
         # Allow editing name, email and languages
-        first_name = request.form.get('first_name')
-        last_name = request.form.get('last_name')
-        email = request.form.get('email')
-        languages = request.form.get('languages')
+        first_name = request.form.get("first_name")
+        last_name = request.form.get("last_name")
+        email = request.form.get("email")
+        languages = request.form.get("languages")
         if first_name and first_name != current_user.first_name:
             current_user.first_name = first_name
         if last_name is not None and last_name != current_user.last_name:
@@ -25,8 +26,8 @@ def view():
         if languages is not None and languages != current_user.languages:
             current_user.languages = languages
         db.session.commit()
-        flash('Profile updated.', 'success')
-        return redirect(url_for('profile.view'))
+        flash("Profile updated.", "success")
+        return redirect(url_for("profile.view"))
 
     opd_result_count = current_user.opd_result_count()
 
@@ -50,7 +51,7 @@ def view():
         slot = SpeakerSlot.query.filter_by(
             debate_id=res.debate_id, user_id=current_user.id
         ).first()
-        role = slot.role.split('-')[0] if slot else None
+        role = slot.role.split("-")[0] if slot else None
 
         style = debate.style
         if slot:
@@ -62,9 +63,7 @@ def view():
         if style == "BP":
             team = role
             if team:
-                bp = BpRank.query.filter_by(
-                    debate_id=res.debate_id, team=team
-                ).first()
+                bp = BpRank.query.filter_by(debate_id=res.debate_id, team=team).first()
                 if bp:
                     rank = bp.rank
         elif style == "OPD" and role in ("Gov", "Opp"):
@@ -143,21 +142,28 @@ def debate_results(debate_id):
     user_map = {u.id: u for u in User.query.filter(User.id.in_(user_ids)).all()}
 
     opd_points = {
-        r.user_id: r.points for r in OpdResult.query.filter_by(debate_id=debate_id).all()
+        r.user_id: r.points
+        for r in OpdResult.query.filter_by(debate_id=debate_id).all()
     }
 
     gov_total = {}
     opp_total = {}
     for room, slots in slots_by_room.items():
-        if room_styles[room] != 'OPD':
+        if room_styles[room] != "OPD":
             continue
-        gov_total[room] = sum(opd_points.get(s.user_id, 0) for s in slots if s.role.startswith('Gov'))
-        opp_total[room] = sum(opd_points.get(s.user_id, 0) for s in slots if s.role.startswith('Opp'))
+        gov_total[room] = sum(
+            opd_points.get(s.user_id, 0) for s in slots if s.role.startswith("Gov")
+        )
+        opp_total[room] = sum(
+            opd_points.get(s.user_id, 0) for s in slots if s.role.startswith("Opp")
+        )
 
-    bp_ranks = {r.team: r.rank for r in BpRank.query.filter_by(debate_id=debate_id).all()}
+    bp_ranks = {
+        r.team: r.rank for r in BpRank.query.filter_by(debate_id=debate_id).all()
+    }
 
     return render_template(
-        'profile/debate_results.html',
+        "profile/debate_results.html",
         debate=debate,
         slots_by_room=slots_by_room,
         room_styles=room_styles,

--- a/app/static/js/dashboard.js
+++ b/app/static/js/dashboard.js
@@ -283,6 +283,17 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   }
 
+  const preferFreeSpeech = document.getElementById('preferFree');
+  if (preferFreeSpeech) {
+    preferFreeSpeech.addEventListener('change', () => {
+      fetch('/profile/prefer_free', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ prefer_free: preferFreeSpeech.checked })
+      });
+    });
+  }
+
   const preferCheck = document.getElementById('preferJudging');
   if (preferCheck) {
     preferCheck.addEventListener('change', () => {

--- a/app/templates/main/dashboard.html
+++ b/app/templates/main/dashboard.html
@@ -15,8 +15,10 @@
   window.currentDebateStyle = "{{ current_debate.style if current_debate else '' }}";
   window.currentUserId = {{ current_user.id }};
   window.userHasSlot = {{ 'true' if user_role else 'false' }};
+  window.userIsFirstTimer = {{ 'true' if is_first_timer else 'false' }};
   window.userIsJudgeChair = {{ 'true' if is_judge_chair else 'false' }};
   window.userJudgeSkill = "{{ current_user.judge_skill or '' }}";
+  window.preferFree = {{ 'true' if prefers_free else 'false' }};
   window.preferJudging = {{ 'true' if prefers_judging else 'false' }};
 </script>
 
@@ -61,6 +63,10 @@
       {% if current_debate and current_debate.assignment_complete and not user_role %}
       <button id="joinLaterBtn" class="btn btn-secondary mt-3" disabled>Join Debate</button>
       {% endif %}
+      <div class="form-check mt-3">
+	<input class="form-check-input" type="checkbox" id="preferFree" {% if prefers_free %}checked{% endif %}>
+      <label class="form-check-label" for="preferFree">Prefer free speech</label>
+      </div>
       <div class="form-check mt-3">
         <input class="form-check-input" type="checkbox" id="preferJudging" {% if prefers_judging %}checked{% endif %}>
         <label class="form-check-label" for="preferJudging">Prefer judging</label>

--- a/app/utils.py
+++ b/app/utils.py
@@ -6,17 +6,17 @@ from flask import current_app
 
 def send_email(to, subject, body):
     msg = EmailMessage()
-    msg['Subject'] = subject
-    msg['From'] = current_app.config.get('MAIL_DEFAULT_SENDER')
-    msg['To'] = to
+    msg["Subject"] = subject
+    msg["From"] = current_app.config.get("MAIL_DEFAULT_SENDER")
+    msg["To"] = to
     msg.set_content(body)
 
-    host = current_app.config.get('MAIL_SERVER', 'localhost')
-    port = current_app.config.get('MAIL_PORT', 25)
-    username = current_app.config.get('MAIL_USERNAME')
-    password = current_app.config.get('MAIL_PASSWORD')
-    use_tls = current_app.config.get('MAIL_USE_TLS', False)
-    use_ssl = current_app.config.get('MAIL_USE_SSL', False)
+    host = current_app.config.get("MAIL_SERVER", "localhost")
+    port = current_app.config.get("MAIL_PORT", 25)
+    username = current_app.config.get("MAIL_USERNAME")
+    password = current_app.config.get("MAIL_PASSWORD")
+    use_tls = current_app.config.get("MAIL_USE_TLS", False)
+    use_ssl = current_app.config.get("MAIL_USE_SSL", False)
 
     if use_ssl:
         smtp = smtplib.SMTP_SSL(host, port)
@@ -31,20 +31,23 @@ def send_email(to, subject, body):
 
 
 def generate_token(email, salt, expires_sec=3600):
-    s = URLSafeTimedSerializer(current_app.config['SECRET_KEY'])
+    s = URLSafeTimedSerializer(current_app.config["SECRET_KEY"])
     return s.dumps(email, salt=salt)
 
 
 def confirm_token(token, salt, expiration=3600):
-    s = URLSafeTimedSerializer(current_app.config['SECRET_KEY'])
+    s = URLSafeTimedSerializer(current_app.config["SECRET_KEY"])
     try:
         email = s.loads(token, salt=salt, max_age=expiration)
     except Exception:
         return None
     return email
+
+
 from sqlalchemy import func
 from .extensions import db
 from .models import Vote, Topic
+
 
 def compute_winning_topic(debate):
     """Return the winning Topic for a debate or None."""

--- a/app/utils.py
+++ b/app/utils.py
@@ -76,7 +76,15 @@ def compute_winning_topic(debate):
     return None
 
 
+def reset_prefer_free():
+    """Reset the prefer_judging flag for all users."""
+    from .models import User
+
+    User.query.update({User.prefer_free: False}, synchronize_session=False)
+
+
 def reset_prefer_judging():
     """Reset the prefer_judging flag for all users."""
     from .models import User
+
     User.query.update({User.prefer_judging: False}, synchronize_session=False)

--- a/config.py
+++ b/config.py
@@ -1,19 +1,24 @@
 import os
 
+
 class Config:
-    SECRET_KEY = os.getenv('SECRET_KEY', 'dev')
-    SQLALCHEMY_DATABASE_URI = os.getenv('SQLALCHEMY_DATABASE_URI', 'sqlite:///debate_app.db')
-    SQLALCHEMY_TRACK_MODIFICATIONS = os.getenv('SQLALCHEMY_TRACK_MODIFICATIONS', 'False').lower() in ('true', '1')
-    CORS_ALLOWED_ORIGINS = os.getenv('CORS_ALLOWED_ORIGINS', '*')
-    PORT = int(os.getenv('PORT', 5000))
-    SERVER_NAME = os.getenv('SERVER_NAME', 'example.com')
-    PREFERRED_URL_SCHEME = os.getenv('PREFERRED_URL_SCHEME', 'http')
+    SECRET_KEY = os.getenv("SECRET_KEY", "dev")
+    SQLALCHEMY_DATABASE_URI = os.getenv(
+        "SQLALCHEMY_DATABASE_URI", "sqlite:///debate_app.db"
+    )
+    SQLALCHEMY_TRACK_MODIFICATIONS = os.getenv(
+        "SQLALCHEMY_TRACK_MODIFICATIONS", "True"
+    ).lower() in ("true", "1")
+    CORS_ALLOWED_ORIGINS = os.getenv("CORS_ALLOWED_ORIGINS", "*")
+    PORT = int(os.getenv("PORT", 5000))
+    SERVER_NAME = os.getenv("SERVER_NAME", "example.com")
+    PREFERRED_URL_SCHEME = os.getenv("PREFERRED_URL_SCHEME", "http")
 
     # Email configuration
-    MAIL_SERVER = os.getenv('MAIL_SERVER', 'localhost')
-    MAIL_PORT = int(os.getenv('MAIL_PORT', 25))
-    MAIL_USERNAME = os.getenv('MAIL_USERNAME')
-    MAIL_PASSWORD = os.getenv('MAIL_PASSWORD')
-    MAIL_USE_TLS = os.getenv('MAIL_USE_TLS', 'False').lower() in ('true', '1')
-    MAIL_USE_SSL = os.getenv('MAIL_USE_SSL', 'False').lower() in ('true', '1')
-    MAIL_DEFAULT_SENDER = os.getenv('MAIL_DEFAULT_SENDER', 'noreply@example.com')
+    MAIL_SERVER = os.getenv("MAIL_SERVER", "localhost")
+    MAIL_PORT = int(os.getenv("MAIL_PORT", 25))
+    MAIL_USERNAME = os.getenv("MAIL_USERNAME")
+    MAIL_PASSWORD = os.getenv("MAIL_PASSWORD")
+    MAIL_USE_TLS = os.getenv("MAIL_USE_TLS", "False").lower() in ("true", "1")
+    MAIL_USE_SSL = os.getenv("MAIL_USE_SSL", "False").lower() in ("true", "1")
+    MAIL_DEFAULT_SENDER = os.getenv("MAIL_DEFAULT_SENDER", "noreply@example.com")


### PR DESCRIPTION
Experience is updated automatically for users of first timer and beginner status (5/15 debate participations respectively), free speech preference feature is implemented for all users (it should be possible to select both and be considered preferentially in both categories), refactoring in assignment logic.

Open question of how to handle a scenario with many users who prefer judging and few volunteers for free speeches, still follows the logic of assigning three speakers first. Keeping users who prefer judging separate might result in fewer speeches and inconsistencies in the initially suggested assignment scenario that predicts the number of judges but would be closer to user preferences. Generally a minor difference in the code, marked at the relevant place in the assignment logic.